### PR TITLE
Show custom catalog types in search discover rows

### DIFF
--- a/js/ui/screens/search/searchScreen.js
+++ b/js/ui/screens/search/searchScreen.js
@@ -584,7 +584,8 @@ export const SearchScreen = {
                 .toLowerCase() === "search" && Boolean(extra?.isRequired)
           );
         if (requiresSearch) return;
-        if (!isSearchableCatalogType(catalog.apiType)) return;
+        if (!isSearchableCatalogType(catalog.apiType) && !catalogSupportsExtra(catalog, "search"))
+          return;
         sections.push({
           addonBaseUrl: addon.baseUrl,
           addonId: addon.id,


### PR DESCRIPTION
Fixes #589.

The actual search was already fixed to target any catalog that supports the `search` extra (in "Fix search for custom catalog types"), so typing a query now returns results for custom catalog types. The one remaining place that still used the hardcoded type allowlist (movie/series/tv/anime) was the discover/browse rows shown on the search screen before you type: loadDiscoverRows dropped any catalog whose type was not in that list, so custom typed catalogs (for example AIOMetadata's `other`, or localized types like German `Film`/`Serie`) never appeared even though they support search.

This adds catalogs that support the `search` extra to the discover rows regardless of type, matching the search targeting. The change is additive: existing allowlist type rows are unchanged, catalogs that require search (cannot be browsed without a query) are still excluded.

Verified the filter with the real catalogSupportsExtra against mixed catalog types:
- `movie` with search, `movie` without search (allowlist) -> kept
- `other` with optional search, `Film` with search -> now included
- `other` with required search -> still excluded (not browsable)