### PR TITLE
fix(webos): preserve audio at increased playback rates

### DIFF
--- a/js/core/player/playerController.js
+++ b/js/core/player/playerController.js
@@ -154,6 +154,9 @@ export const PlayerController = {
   startupPresentationAudioMuted: false,
   desiredPlaybackRate: 1,
   appliedAvPlayPlaybackRate: 1,
+  appliedWebOsPlaybackRate: 1,
+  webOsPlaybackRateRequestToken: 0,
+  webOsPlaybackRateReapplyPromise: null,
 
   isExpectedPlayInterruption(error) {
     const message = String(error?.message || "").toLowerCase();
@@ -522,6 +525,9 @@ export const PlayerController = {
   resetNativeMediaState() {
     this.nativeMediaId = "";
     this.nativeMediaIdLookupToken = Number(this.nativeMediaIdLookupToken || 0) + 1;
+    this.webOsPlaybackRateRequestToken = Number(this.webOsPlaybackRateRequestToken || 0) + 1;
+    this.appliedWebOsPlaybackRate = 1;
+    this.webOsPlaybackRateReapplyPromise = null;
     this.cancelWebOsAudioTrackSelection();
     this.selectedWebOsEmbeddedAudioTrackIndex = -1;
     this.selectedWebOsEmbeddedSubtitleTrackIndex = -1;
@@ -3682,6 +3688,11 @@ export const PlayerController = {
       // video, so only expose the rate that preserves A/V synchronization.
       return [1];
     }
+    if (Platform.isWebOS() && !this.isUsingNativePlayback()) {
+      // MSE-backed hls.js/dash.js playback never exposes a mediaId, so the
+      // native Luna setPlayRate command cannot target that pipeline.
+      return [1];
+    }
     return [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
   },
 
@@ -3745,6 +3756,84 @@ export const PlayerController = {
     return this.applyAvPlayPlaybackRate(targetSpeed);
   },
 
+  isSupportedWebOsPlaybackRate(speed = 1) {
+    const targetSpeed = this.normalizePlaybackRate(speed);
+    if (!Number.isFinite(targetSpeed) || targetSpeed > 2) {
+      return false;
+    }
+    if (targetSpeed === 1) {
+      return true;
+    }
+    return Platform.isWebOS() && this.isUsingNativePlayback();
+  },
+
+  async applyWebOsPlaybackRate(speed = this.desiredPlaybackRate) {
+    if (!Platform.isWebOS() || !this.video || !this.isUsingNativePlayback()) {
+      return false;
+    }
+    const targetSpeed = this.normalizePlaybackRate(speed);
+    if (!this.isSupportedWebOsPlaybackRate(targetSpeed)) {
+      return false;
+    }
+
+    // A native webOS pipeline publishes its private mediaId asynchronously.
+    // MSE pipelines never publish one, which is why they are rejected above.
+    const mediaId =
+      this.syncNativeMediaId() ||
+      (await this.waitForNativeMediaId({ maxAttempts: 20, intervalMs: 250 }));
+    if (!mediaId) {
+      return false;
+    }
+    // Treat nativeMediaIdLookupToken as the native-pipeline generation. Once
+    // mediaId exists, waitForNativeMediaId() does not increment it, so a later
+    // token change means the source was reset while this Luna command was in
+    // flight.
+    const nativeMediaStateToken = Number(this.nativeMediaIdLookupToken || 0);
+
+    try {
+      // Do not locally time out this command. Luna requests cannot be cancelled
+      // through the shared wrapper, so declaring failure while one is still in
+      // flight can let a late success change the native rate after the UI has
+      // reverted to its previous value.
+      const result = await this.requestWebOsMediaCommand("setPlayRate", {
+        mediaId,
+        playRate: targetSpeed,
+        audioOutput: true
+      });
+      if (result?.returnValue !== true) {
+        return false;
+      }
+      if (nativeMediaStateToken !== Number(this.nativeMediaIdLookupToken || 0)) {
+        return false;
+      }
+      this.appliedWebOsPlaybackRate = targetSpeed;
+      return true;
+    } catch (_) {
+      return false;
+    }
+  },
+
+  reapplyWebOsPlaybackRate() {
+    if (
+      !Platform.isWebOS() ||
+      !this.video ||
+      !this.isUsingNativePlayback() ||
+      this.desiredPlaybackRate === 1
+    ) {
+      return Promise.resolve(false);
+    }
+    if (this.webOsPlaybackRateReapplyPromise) {
+      return this.webOsPlaybackRateReapplyPromise;
+    }
+    const reapplyPromise = this.applyWebOsPlaybackRate(this.desiredPlaybackRate).finally(() => {
+      if (this.webOsPlaybackRateReapplyPromise === reapplyPromise) {
+        this.webOsPlaybackRateReapplyPromise = null;
+      }
+    });
+    this.webOsPlaybackRateReapplyPromise = reapplyPromise;
+    return reapplyPromise;
+  },
+
   getPlaybackRate() {
     const targetSpeed = this.normalizePlaybackRate(this.desiredPlaybackRate);
     if (Number.isFinite(targetSpeed)) {
@@ -3753,7 +3842,7 @@ export const PlayerController = {
     return Number(this.video?.playbackRate || 1);
   },
 
-  setPlaybackRate(speed = 1) {
+  async setPlaybackRate(speed = 1) {
     if (!this.video) {
       return false;
     }
@@ -3774,23 +3863,37 @@ export const PlayerController = {
       return true;
     }
 
-    this.desiredPlaybackRate = targetSpeed;
+    if (Platform.isWebOS()) {
+      if (!this.isSupportedWebOsPlaybackRate(targetSpeed)) {
+        return false;
+      }
+      if (!this.isUsingNativePlayback()) {
+        // A non-native (MSE) pipeline is already at normal speed and has no
+        // mediaId that Luna can address.
+        if (targetSpeed === 1) {
+          this.desiredPlaybackRate = 1;
+          this.appliedWebOsPlaybackRate = 1;
+          return true;
+        }
+        return false;
+      }
+
+      const requestToken = Number(this.webOsPlaybackRateRequestToken || 0) + 1;
+      this.webOsPlaybackRateRequestToken = requestToken;
+      const applied = await this.applyWebOsPlaybackRate(targetSpeed);
+      if (!applied || requestToken !== this.webOsPlaybackRateRequestToken) {
+        return false;
+      }
+      this.desiredPlaybackRate = targetSpeed;
+      return true;
+    }
+
     try {
       this.video.playbackRate = targetSpeed;
     } catch (_) {
-      // webOS native playback can still accept the Luna play-rate command.
+      return false;
     }
-
-    const mediaId = this.syncNativeMediaId();
-    if (Platform.isWebOS() && mediaId) {
-      this.requestWebOsMediaCommand("setPlayRate", {
-        mediaId,
-        playRate: targetSpeed,
-        audioOutput: true
-      }).catch(() => {
-        // Keep the media-element playbackRate fallback.
-      });
-    }
+    this.desiredPlaybackRate = targetSpeed;
 
     return true;
   },
@@ -4238,13 +4341,19 @@ export const PlayerController = {
       });
     });
 
-    const syncNativeMediaId = () => {
+    const syncNativeMediaId = (event) => {
       this.syncNativeMediaId();
+      if (event?.type === "canplay" || event?.type === "playing") {
+        this.reapplyWebOsPlaybackRate().catch(() => {});
+      }
     };
     this.video.addEventListener("loadedmetadata", syncNativeMediaId);
     this.video.addEventListener("loadeddata", syncNativeMediaId);
     this.video.addEventListener("canplay", syncNativeMediaId);
     this.video.addEventListener("playing", syncNativeMediaId);
+    this.video.addEventListener("seeked", () => {
+      this.reapplyWebOsPlaybackRate().catch(() => {});
+    });
     this.video.addEventListener("emptied", () => {
       this.resetNativeMediaState();
     });

--- a/js/core/player/playerController.js
+++ b/js/core/player/playerController.js
@@ -156,6 +156,7 @@ export const PlayerController = {
   appliedAvPlayPlaybackRate: 1,
   appliedWebOsPlaybackRate: 1,
   webOsPlaybackRateRequestToken: 0,
+  webOsPlaybackRateCommandPromise: null,
   webOsPlaybackRateReapplyPromise: null,
 
   isExpectedPlayInterruption(error) {
@@ -527,6 +528,7 @@ export const PlayerController = {
     this.nativeMediaIdLookupToken = Number(this.nativeMediaIdLookupToken || 0) + 1;
     this.webOsPlaybackRateRequestToken = Number(this.webOsPlaybackRateRequestToken || 0) + 1;
     this.appliedWebOsPlaybackRate = 1;
+    this.webOsPlaybackRateCommandPromise = null;
     this.webOsPlaybackRateReapplyPromise = null;
     this.cancelWebOsAudioTrackSelection();
     this.selectedWebOsEmbeddedAudioTrackIndex = -1;
@@ -3813,6 +3815,22 @@ export const PlayerController = {
     }
   },
 
+  queueWebOsPlaybackRate(speed = this.desiredPlaybackRate) {
+    const previousCommand = this.webOsPlaybackRateCommandPromise;
+    const commandPromise = previousCommand
+      ? Promise.resolve(previousCommand)
+          .catch(() => false)
+          .then(() => this.applyWebOsPlaybackRate(speed))
+      : this.applyWebOsPlaybackRate(speed);
+    const trackedPromise = commandPromise.finally(() => {
+      if (this.webOsPlaybackRateCommandPromise === trackedPromise) {
+        this.webOsPlaybackRateCommandPromise = null;
+      }
+    });
+    this.webOsPlaybackRateCommandPromise = trackedPromise;
+    return trackedPromise;
+  },
+
   reapplyWebOsPlaybackRate() {
     if (
       !Platform.isWebOS() ||
@@ -3825,7 +3843,7 @@ export const PlayerController = {
     if (this.webOsPlaybackRateReapplyPromise) {
       return this.webOsPlaybackRateReapplyPromise;
     }
-    const reapplyPromise = this.applyWebOsPlaybackRate(this.desiredPlaybackRate).finally(() => {
+    const reapplyPromise = this.queueWebOsPlaybackRate(this.desiredPlaybackRate).finally(() => {
       if (this.webOsPlaybackRateReapplyPromise === reapplyPromise) {
         this.webOsPlaybackRateReapplyPromise = null;
       }
@@ -3880,7 +3898,7 @@ export const PlayerController = {
 
       const requestToken = Number(this.webOsPlaybackRateRequestToken || 0) + 1;
       this.webOsPlaybackRateRequestToken = requestToken;
-      const applied = await this.applyWebOsPlaybackRate(targetSpeed);
+      const applied = await this.queueWebOsPlaybackRate(targetSpeed);
       if (!applied || requestToken !== this.webOsPlaybackRateRequestToken) {
         return false;
       }

--- a/js/core/player/playerController.test.mjs
+++ b/js/core/player/playerController.test.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { PlayerController } from "./playerController.js";
+import { Platform } from "../../platform/index.js";
+
+function resetController() {
+  PlayerController.video = null;
+  PlayerController.playbackEngine = "none";
+  PlayerController.avplayActive = false;
+  PlayerController.nativeMediaId = "";
+  PlayerController.desiredPlaybackRate = 1;
+  PlayerController.appliedAvPlayPlaybackRate = 1;
+  PlayerController.appliedWebOsPlaybackRate = 1;
+  PlayerController.webOsPlaybackRateRequestToken = 0;
+  PlayerController.webOsPlaybackRateReapplyPromise = null;
+}
+
+test("webOS playback rate uses Luna without writing HTMLMediaElement.playbackRate", async () => {
+  const originalPlatform = Platform.current;
+  const originalWebOs = globalThis.webOS;
+  let playbackRateWrites = 0;
+  const commands = [];
+
+  try {
+    Platform.current = { name: "webos" };
+    globalThis.webOS = {
+      service: {
+        request(service, options) {
+          commands.push({ service, method: options.method, parameters: options.parameters });
+          options.onSuccess({ returnValue: true });
+        }
+      }
+    };
+    resetController();
+    PlayerController.video = {
+      mediaId: "media-1",
+      get playbackRate() {
+        return 1;
+      },
+      set playbackRate(_value) {
+        playbackRateWrites += 1;
+      }
+    };
+    PlayerController.playbackEngine = "native-file";
+
+    assert.equal(await PlayerController.setPlaybackRate(1.5), true);
+    assert.equal(PlayerController.getPlaybackRate(), 1.5);
+    assert.equal(playbackRateWrites, 0);
+    assert.deepEqual(commands.at(-1), {
+      service: "luna://com.webos.media",
+      method: "setPlayRate",
+      parameters: { mediaId: "media-1", playRate: 1.5, audioOutput: true }
+    });
+
+    assert.equal(await PlayerController.reapplyWebOsPlaybackRate(), true);
+    assert.equal(commands.at(-1).parameters.playRate, 1.5);
+  } finally {
+    resetController();
+    Platform.current = originalPlatform;
+    globalThis.webOS = originalWebOs;
+  }
+});
+
+test("webOS waits for a delayed Luna playback-rate response", async (t) => {
+  const originalPlatform = Platform.current;
+  const originalWebOs = globalThis.webOS;
+
+  try {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    Platform.current = { name: "webos" };
+    globalThis.webOS = {
+      service: {
+        request(_service, options) {
+          setTimeout(() => options.onSuccess({ returnValue: true }), 4000);
+        }
+      }
+    };
+    resetController();
+    PlayerController.video = { mediaId: "media-delayed", playbackRate: 1 };
+    PlayerController.playbackEngine = "native-file";
+
+    let settledResult;
+    const ratePromise = PlayerController.setPlaybackRate(1.5).then((result) => {
+      settledResult = result;
+      return result;
+    });
+
+    t.mock.timers.tick(3001);
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(settledResult, undefined);
+    assert.equal(PlayerController.getPlaybackRate(), 1);
+
+    t.mock.timers.tick(999);
+    assert.equal(await ratePromise, true);
+    assert.equal(PlayerController.getPlaybackRate(), 1.5);
+  } finally {
+    resetController();
+    Platform.current = originalPlatform;
+    globalThis.webOS = originalWebOs;
+  }
+});
+
+test("webOS ignores a pending playback-rate result after a source reset", async () => {
+  const originalPlatform = Platform.current;
+  const originalWebOs = globalThis.webOS;
+  let resolveRequest;
+
+  try {
+    Platform.current = { name: "webos" };
+    globalThis.webOS = {
+      service: {
+        request(_service, options) {
+          resolveRequest = () => options.onSuccess({ returnValue: true });
+        }
+      }
+    };
+    resetController();
+    PlayerController.video = { mediaId: "media-old", playbackRate: 1 };
+    PlayerController.playbackEngine = "native-file";
+
+    const ratePromise = PlayerController.setPlaybackRate(1.5);
+    await Promise.resolve();
+    PlayerController.resetNativeMediaState();
+    PlayerController.video.mediaId = "media-new";
+    resolveRequest();
+
+    assert.equal(await ratePromise, false);
+    assert.equal(PlayerController.getPlaybackRate(), 1);
+    assert.equal(PlayerController.appliedWebOsPlaybackRate, 1);
+  } finally {
+    resetController();
+    Platform.current = originalPlatform;
+    globalThis.webOS = originalWebOs;
+  }
+});
+
+test("webOS MSE playback does not expose unsupported speed choices", async () => {
+  const originalPlatform = Platform.current;
+
+  try {
+    Platform.current = { name: "webos" };
+    resetController();
+    PlayerController.video = { playbackRate: 1 };
+    PlayerController.playbackEngine = "dash.js";
+
+    assert.deepEqual(PlayerController.getSupportedPlaybackRates(), [1]);
+    assert.equal(await PlayerController.setPlaybackRate(1.25), false);
+    assert.equal(PlayerController.getPlaybackRate(), 1);
+  } finally {
+    resetController();
+    Platform.current = originalPlatform;
+  }
+});
+
+test("Tizen AVPlay behavior remains isolated from the webOS workaround", async () => {
+  const originalPlatform = Platform.current;
+  const originalWebApis = globalThis.webapis;
+  let playbackRateWrites = 0;
+  let avplaySpeedCalls = 0;
+
+  try {
+    Platform.current = { name: "tizen" };
+    globalThis.webapis = {
+      avplay: {
+        open() {},
+        getState() {
+          return "PLAYING";
+        },
+        setSpeed() {
+          avplaySpeedCalls += 1;
+        }
+      }
+    };
+    resetController();
+    PlayerController.video = {
+      get playbackRate() {
+        return 1;
+      },
+      set playbackRate(_value) {
+        playbackRateWrites += 1;
+      }
+    };
+    PlayerController.playbackEngine = "tizen-avplay";
+    PlayerController.avplayActive = true;
+
+    assert.deepEqual(PlayerController.getSupportedPlaybackRates(), [1]);
+    assert.equal(await PlayerController.setPlaybackRate(1.25), false);
+    assert.equal(await PlayerController.setPlaybackRate(1), true);
+    assert.equal(playbackRateWrites, 0);
+    assert.equal(avplaySpeedCalls, 0);
+  } finally {
+    resetController();
+    Platform.current = originalPlatform;
+    globalThis.webapis = originalWebApis;
+  }
+});

--- a/js/core/player/playerController.test.mjs
+++ b/js/core/player/playerController.test.mjs
@@ -13,6 +13,7 @@ function resetController() {
   PlayerController.appliedAvPlayPlaybackRate = 1;
   PlayerController.appliedWebOsPlaybackRate = 1;
   PlayerController.webOsPlaybackRateRequestToken = 0;
+  PlayerController.webOsPlaybackRateCommandPromise = null;
   PlayerController.webOsPlaybackRateReapplyPromise = null;
 }
 
@@ -129,6 +130,44 @@ test("webOS ignores a pending playback-rate result after a source reset", async 
     assert.equal(await ratePromise, false);
     assert.equal(PlayerController.getPlaybackRate(), 1);
     assert.equal(PlayerController.appliedWebOsPlaybackRate, 1);
+  } finally {
+    resetController();
+    Platform.current = originalPlatform;
+    globalThis.webOS = originalWebOs;
+  }
+});
+
+test("latest webOS playback-rate selection wins when Luna responses arrive out of order", async () => {
+  const originalPlatform = Platform.current;
+  const originalWebOs = globalThis.webOS;
+  const pendingRequests = [];
+
+  try {
+    Platform.current = { name: "webos" };
+    globalThis.webOS = {
+      service: {
+        request(_service, options) {
+          pendingRequests.push(options);
+        }
+      }
+    };
+    resetController();
+    PlayerController.video = { mediaId: "media-race", playbackRate: 1 };
+    PlayerController.playbackEngine = "native-file";
+
+    const firstRatePromise = PlayerController.setPlaybackRate(1.25);
+    const secondRatePromise = PlayerController.setPlaybackRate(1.5);
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(pendingRequests.length, 1);
+    pendingRequests[0].onSuccess({ returnValue: true });
+    assert.equal(await firstRatePromise, false);
+    await Promise.resolve();
+    assert.equal(pendingRequests.length, 2);
+    pendingRequests[1].onSuccess({ returnValue: true });
+    assert.equal(await secondRatePromise, true);
+    assert.equal(PlayerController.getPlaybackRate(), 1.5);
+    assert.equal(PlayerController.appliedWebOsPlaybackRate, 1.5);
   } finally {
     resetController();
     Platform.current = originalPlatform;

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -16406,16 +16406,24 @@ export const PlayerScreen = {
     this.resetControlsAutoHide();
   },
 
-  applyPlaybackSpeed(speed = 1) {
-    const applied =
-      typeof PlayerController.setPlaybackRate === "function"
-        ? PlayerController.setPlaybackRate(speed)
-        : false;
+  async applyPlaybackSpeed(speed = 1) {
+    let applied = false;
+    try {
+      applied =
+        typeof PlayerController.setPlaybackRate === "function"
+          ? await PlayerController.setPlaybackRate(speed)
+          : false;
+    } catch (_) {
+      applied = false;
+    }
     if (!applied) {
-      return;
+      this.renderControlButtons();
+      this.renderSpeedDialog();
+      return false;
     }
     this.renderControlButtons();
     this.renderSpeedDialog();
+    return true;
   },
 
   renderSpeedDialog() {


### PR DESCRIPTION
## Summary

Preserve audio during accelerated native playback on LG webOS by driving playback rate exclusively through `com.webos.media/setPlayRate`, waiting for the native `mediaId`, validating the Luna response, and restoring the rate after native pipeline resets.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [x] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

On affected LG webOS native playback, selecting `1.25x` or `1.5x` accelerated video but silenced audio. The player wrote `HTMLMediaElement.playbackRate` before issuing the native Luna command; that property is unreliable on the webOS native media pipeline and can leave audio muted.

The Luna request also depended on `mediaId` being immediately available, ignored unsuccessful responses, and was not restored after seek/replay pipeline resets.

## Issue or approval

Fixes #671

## Reproduction steps

1. Install Nuvio TV on an LG webOS TV.
2. Start a movie or episode using native/direct playback.
3. Open playback speed and select `1.25x` or `1.5x`.
4. Continue playback or seek forward.

## Old behavior

Video accelerated, but audio became silent. The UI reported the selected rate even when the native command could not be applied.

## New behavior

- webOS native playback never writes `HTMLMediaElement.playbackRate`.
- The player polls up to five seconds for the asynchronous native `mediaId`.
- `setPlayRate` uses `audioOutput: true`, waits for the Luna response and must return `returnValue: true` before the UI accepts the rate.
- The selected Luna rate is reapplied after `canplay`, `playing`, and `seeked`.
- MSE-backed hls.js/dash.js playback exposes only `1x` because those pipelines have no native `mediaId`.
- Other platforms retain their existing playback-rate paths.

## Platform impact

- Samsung Tizen: Existing AVPlay path remains restricted to `1x`; covered by a platform-isolation regression test and successful WGT packaging.
- LG webOS: Native playback uses the verified Luna-only playback-rate path. MSE playback is limited to `1x`.
- Browser development mode: Existing HTML media-element playback-rate path is unchanged.
- Installer / packaging: No source changes to installer or packaging logic. Both platform packages were built for verification.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

This PR does not add a remuxer or attempt to synthesize progressive MP4 alternatives for MSE-only sources. It does not change stream selection, codecs, UI layout, package metadata, app identifiers, dependencies, or wrapper behavior.

## Testing

### Devices / platforms tested

- LG OLED65G56LS (G5), webOS SDK 10.3.1, firmware 33.31.68: installed IPK and manually verified native playback at `1.5x` with audible synchronized audio before and after seeking.
- Samsung Tizen: AVPlay behavior covered by an automated platform-isolation test; no physical Samsung TV available.
- Node-based mocks: webOS Luna success, concurrent rate-command serialization, webOS MSE rejection, and Tizen AVPlay isolation.

### Commands tested

```sh
npx prettier --check js/core/player/playerController.test.mjs
npx eslint js/core/player/playerController.js js/core/player/playerController.test.mjs js/ui/screens/player/playerScreen.js
npm test
npm run build
npm run package:tizen
npm run package:webos
npm run install:webos -- -d tv
```

All commands completed successfully. The repository-wide pre-commit `format:check` still reports unrelated pre-existing formatting warnings in 32 untouched files; the changed files passed targeted formatting and lint checks.

## Manual test flow

1. Installed `space.nuvio.webos_0.3.34_all.ipk` on the LG G5 through Developer Mode.
2. Launched Nuvio and started native/direct playback.
3. Selected `1.5x` and played for approximately ten seconds.
4. Confirmed audio remained audible and synchronized.
5. Sought forward and continued playback.
6. Confirmed accelerated playback and audio continued after the seek reset.

## Screenshots / Video

Not a UI change.

## Logs

- `ares-device -i` confirmed the target as LG OLED65G56LS with SDK 10.3.1 and firmware 33.31.68.
- webOS IPK installation and application launch completed successfully.
- No crash, blank screen, or playback error occurred during the manual validation flow.

## Regression risk

The shared controller method is now asynchronous, and its sole UI caller awaits the result. Tizen branches before all new webOS logic and has dedicated regression coverage. Browser playback still uses `HTMLMediaElement.playbackRate`. The main residual risk is undocumented Luna behavior varying across older LG firmware or media codecs; failed/unsupported commands now leave the previous rate selected instead of reporting false success.

## Breaking changes

None.

## Linked issues

Fixes #671
