### PR TITLE
Parse stream size from title text when no size field

### DIFF
--- a/js/core/debrid/directDebridStreamPresentation.js
+++ b/js/core/debrid/directDebridStreamPresentation.js
@@ -1,6 +1,7 @@
 import { DebridSettingsStore } from "../../data/local/debridSettingsStore.js";
 import { DEBRID_PROVIDER_IDS, DebridProviders } from "./debridProviders.js";
 import { DebridStreamTemplateEngine } from "./debridStreamTemplateEngine.js";
+import { sizeBytesFromStreamText } from "./streamTextSizeParser.js";
 
 const RESOLUTION_RANK = {
   P2160: 700,
@@ -417,6 +418,7 @@ function streamSize(stream = {}) {
       resolve.stream?.raw?.size ??
         stream.behaviorHints?.videoSize ??
         stream.debridCacheStatus?.cachedSize ??
+        sizeBytesFromStreamText(stream) ??
         0
     ) || 0
   );
@@ -915,7 +917,11 @@ function buildTemplateValues(stream = {}, fact = {}) {
       : (fact.languages || []).map((language) => LANGUAGE_LABELS[language]?.[0]).filter(Boolean)
     ).map(languageEmoji),
     "stream.size":
-      raw.size ?? stream.behaviorHints?.videoSize ?? stream.debridCacheStatus?.cachedSize ?? null,
+      raw.size ??
+      stream.behaviorHints?.videoSize ??
+      stream.debridCacheStatus?.cachedSize ??
+      sizeBytesFromStreamText(stream) ??
+      null,
     "stream.folderSize": raw.folderSize ?? null,
     "stream.encode": parsed.codec
       ? String(parsed.codec).toUpperCase()

--- a/js/core/debrid/streamTextSizeParser.js
+++ b/js/core/debrid/streamTextSizeParser.js
@@ -1,0 +1,43 @@
+// Parses a file size out of free-text stream metadata. Add-ons like Torrentio
+// embed the size in the stream title (for example "👤 12 💾 1.81 GB ⚙️ TPB")
+// instead of a structured size field, so this is the last resort fallback for
+// size display, filtering, and sorting.
+
+const SIZE_REGEX = /(\d+(?:[.,]\d+)?)\s*(TB|GB|MB|KB)\b/i;
+const KILO = 1024;
+
+const UNIT_MULTIPLIERS = {
+  TB: KILO * KILO * KILO * KILO,
+  GB: KILO * KILO * KILO,
+  MB: KILO * KILO,
+  KB: KILO
+};
+
+export function sizeBytesFromText(text) {
+  const value = String(text ?? "").trim();
+  if (!value) {
+    return null;
+  }
+  const match = value.match(SIZE_REGEX);
+  if (!match) {
+    return null;
+  }
+  const amount = Number(match[1].replace(/,/g, "."));
+  if (!Number.isFinite(amount)) {
+    return null;
+  }
+  const multiplier = UNIT_MULTIPLIERS[match[2].toUpperCase()];
+  if (!multiplier) {
+    return null;
+  }
+  const bytes = Math.trunc(amount * multiplier);
+  return bytes > 0 ? bytes : null;
+}
+
+export function sizeBytesFromStreamText(stream = {}) {
+  return (
+    sizeBytesFromText(stream.description) ??
+    sizeBytesFromText(stream.title) ??
+    sizeBytesFromText(stream.name)
+  );
+}

--- a/js/core/debrid/streamTextSizeParser.test.mjs
+++ b/js/core/debrid/streamTextSizeParser.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { sizeBytesFromStreamText, sizeBytesFromText } from "./streamTextSizeParser.js";
+
+test("parses torrentio style size line", () => {
+  const torrentioTitle = "Movie.Name.2024.1080p.WEB-DL\n👤 12 💾 1.81 GB ⚙️ ThePirateBay";
+  assert.equal(sizeBytesFromText(torrentioTitle), Math.trunc(1.81 * 1024 ** 3));
+});
+
+test("parses plain sizes across units", () => {
+  assert.equal(sizeBytesFromText("700 MB"), 700 * 1024 * 1024);
+  assert.equal(sizeBytesFromText("1.5 TB"), Math.trunc(1.5 * 1024 ** 4));
+  assert.equal(sizeBytesFromText("512KB"), 512 * 1024);
+});
+
+test("parses comma decimal separator", () => {
+  assert.equal(sizeBytesFromText("💾 2,4 GB"), Math.trunc(2.4 * 1024 ** 3));
+});
+
+test("does not misread resolution year or bitrate tokens", () => {
+  assert.equal(sizeBytesFromText("Movie.2024.2160p.x265.10bit"), null);
+  assert.equal(sizeBytesFromText("audio 320kbps AAC"), null);
+  assert.equal(sizeBytesFromText(null), null);
+  assert.equal(sizeBytesFromText("  "), null);
+});
+
+test("stream text lookup prefers description then title then name", () => {
+  const stream = { name: "Torrentio 4k", title: "Movie\n💾 2 GB", description: "💾 1 GB" };
+  assert.equal(sizeBytesFromStreamText(stream), 1024 ** 3);
+
+  const titleOnly = { name: "Torrentio 4k", title: "Movie\n💾 2 GB", description: null };
+  assert.equal(sizeBytesFromStreamText(titleOnly), 2 * 1024 ** 3);
+});


### PR DESCRIPTION
Some addons like Torrentio put the file size in the stream title (for example "1.81 GB") instead of a size field. On those streams the size was missing, so the direct debrid list showed no size and could not filter or sort by size.

This reads the size from the title text as a fallback, the same way the Android app does with StreamTextSizeParser. Structured size fields still win when present.

Added a test that mirrors the Android parser tests.