### PR TITLE
Hide unreleased content on home and search

### DIFF
--- a/js/core/util/releaseInfoUtils.js
+++ b/js/core/util/releaseInfoUtils.js
@@ -1,0 +1,125 @@
+/**
+ * Web port of the Android TV app's release filtering (core/util/ReleaseInfoUtils.kt
+ * and the isEpisodeReleaseAired helper from core/util/EpisodeReleaseDateParser.kt).
+ *
+ * Used to honour the "Hide unreleased content" setting, matching the Android TV
+ * behaviour of dropping catalog items whose release date has not been reached.
+ */
+
+const YEAR_REGEX = /\b(19|20)\d{2}\b/;
+
+/**
+ * Whether a release value has been reached. Returns true/false when the value is a
+ * real date or timestamp, or null when it carries no parseable date so callers can
+ * fall back to the release year. Mirrors EpisodeReleaseDateParser.isEpisodeReleaseAired.
+ *
+ * @param {string} raw
+ * @param {number} nowMs
+ * @returns {boolean|null}
+ */
+function episodeReleaseAired(raw, nowMs) {
+  const releaseMs = parseReleaseInstant(raw);
+  if (releaseMs == null) {
+    return null;
+  }
+  return releaseMs <= nowMs;
+}
+
+/**
+ * Turns a release string into a millisecond instant. A zoned timestamp keeps its exact
+ * instant, a zoneless timestamp is read in the viewer's timezone, and a plain date is
+ * treated as UTC midnight. Returns null when nothing parseable is found.
+ *
+ * @param {string} raw
+ * @returns {number|null}
+ */
+function parseReleaseInstant(raw) {
+  const value = String(raw || "").trim();
+  if (!value) {
+    return null;
+  }
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value)) {
+    const exact = Date.parse(value);
+    if (Number.isFinite(exact)) {
+      return exact;
+    }
+  }
+  const datePortion = (value.match(/\b\d{4}-\d{2}-\d{2}\b/) || [])[0];
+  const dateMs = datePortion ? Date.parse(datePortion) : NaN;
+  return Number.isFinite(dateMs) ? dateMs : null;
+}
+
+/**
+ * Whether a catalog item has not been released yet. Mirrors MetaPreview.isUnreleased:
+ * the exact release timestamp wins, then the release info as a date, then the release
+ * year compared against the current year.
+ *
+ * @param {{ released?: string, releaseInfo?: string }} item
+ * @param {number} [nowMs]
+ * @param {number} [todayYear]
+ * @returns {boolean}
+ */
+export function isUnreleased(item, nowMs = Date.now(), todayYear = new Date(nowMs).getFullYear()) {
+  const released = String(item?.released || "").trim();
+  if (released) {
+    const aired = episodeReleaseAired(released, nowMs);
+    if (aired != null) {
+      return !aired;
+    }
+  }
+
+  const info = item?.releaseInfo;
+  if (info == null) {
+    return false;
+  }
+  const infoText = String(info).trim();
+  const airedFromInfo = episodeReleaseAired(infoText, nowMs);
+  if (airedFromInfo != null) {
+    return !airedFromInfo;
+  }
+  const yearMatch = YEAR_REGEX.exec(infoText);
+  if (!yearMatch) {
+    return false;
+  }
+  const year = Number.parseInt(yearMatch[0], 10);
+  if (!Number.isFinite(year)) {
+    return false;
+  }
+  return year > todayYear;
+}
+
+/**
+ * Drops unreleased items from a catalog list. Returns the same array reference when
+ * nothing is filtered, matching CatalogRow.filterReleasedItems.
+ *
+ * @param {Array<{ released?: string, releaseInfo?: string }>} items
+ * @param {number} [nowMs]
+ * @param {number} [todayYear]
+ * @returns {Array}
+ */
+export function filterReleasedItems(
+  items,
+  nowMs = Date.now(),
+  todayYear = new Date(nowMs).getFullYear()
+) {
+  if (!Array.isArray(items)) {
+    return items;
+  }
+  const filtered = items.filter((item) => !isUnreleased(item, nowMs, todayYear));
+  return filtered.length === items.length ? items : filtered;
+}
+
+/**
+ * True when the item carries no release information at all. Only meaningful for sources
+ * where dates are authoritative. Mirrors MetaPreview.hasNoReleaseInfo.
+ *
+ * @param {{ released?: string, releaseInfo?: string }} item
+ * @returns {boolean}
+ */
+export function hasNoReleaseInfo(item) {
+  return isBlank(item?.released) && isBlank(item?.releaseInfo);
+}
+
+function isBlank(value) {
+  return value == null || String(value).trim() === "";
+}

--- a/js/core/util/releaseInfoUtils.test.mjs
+++ b/js/core/util/releaseInfoUtils.test.mjs
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isUnreleased, filterReleasedItems, hasNoReleaseInfo } from "./releaseInfoUtils.js";
+
+const YEAR_2026 = 2026;
+
+// Mirrors ReleaseInfoUtilsTest.kt from the Android TV app.
+
+test("catalog release filtering uses exact timestamp", () => {
+  const item = { released: "2026-07-15T15:00:00Z" };
+
+  assert.equal(isUnreleased(item, Date.parse("2026-07-15T14:59:59Z"), YEAR_2026), true);
+  assert.equal(isUnreleased(item, Date.parse("2026-07-15T15:00:00Z"), YEAR_2026), false);
+});
+
+test("catalog date only release starts at utc midnight", () => {
+  const item = { released: "2026-07-15" };
+
+  assert.equal(isUnreleased(item, Date.parse("2026-07-14T23:59:59Z"), 2026), true);
+  assert.equal(isUnreleased(item, Date.parse("2026-07-15T00:00:00Z"), 2026), false);
+});
+
+test("undated item is not caught by date-based isUnreleased", () => {
+  const item = { released: null };
+  assert.equal(isUnreleased(item, Date.parse("2026-07-28T00:00:00Z"), 2026), false);
+});
+
+test("undated item is flagged by hasNoReleaseInfo", () => {
+  assert.equal(hasNoReleaseInfo({ released: null }), true);
+  assert.equal(hasNoReleaseInfo({ released: " ", releaseInfo: "" }), true);
+});
+
+test("dated items are not flagged by hasNoReleaseInfo", () => {
+  assert.equal(hasNoReleaseInfo({ released: "2022-05-27" }), false);
+  assert.equal(hasNoReleaseInfo({ released: null, releaseInfo: "2022" }), false);
+});
+
+// Release-year fallback, used when items only carry a releaseInfo string.
+
+test("future release year is unreleased, current and past years are not", () => {
+  assert.equal(isUnreleased({ releaseInfo: "2027" }, Date.now(), YEAR_2026), true);
+  assert.equal(isUnreleased({ releaseInfo: "2026" }, Date.now(), YEAR_2026), false);
+  assert.equal(isUnreleased({ releaseInfo: "2020" }, Date.now(), YEAR_2026), false);
+});
+
+test("release year range uses the first year", () => {
+  assert.equal(isUnreleased({ releaseInfo: "2020-2023" }, Date.now(), YEAR_2026), false);
+});
+
+test("missing release info is treated as released", () => {
+  assert.equal(isUnreleased({}, Date.now(), YEAR_2026), false);
+  assert.equal(isUnreleased({ releaseInfo: "" }, Date.now(), YEAR_2026), false);
+});
+
+test("filterReleasedItems keeps the same array when nothing is filtered", () => {
+  const items = [{ releaseInfo: "2020" }, { released: "2021-01-01" }];
+  assert.equal(filterReleasedItems(items, Date.parse("2026-01-01T00:00:00Z"), 2026), items);
+});
+
+test("filterReleasedItems drops unreleased items", () => {
+  const items = [
+    { name: "old", releaseInfo: "2020" },
+    { name: "future", releaseInfo: "2030" },
+    { name: "dated future", released: "2030-01-01" }
+  ];
+  const filtered = filterReleasedItems(items, Date.parse("2026-01-01T00:00:00Z"), 2026);
+  assert.deepEqual(
+    filtered.map((item) => item.name),
+    ["old"]
+  );
+});

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -11,6 +11,7 @@ import {
   LibrarySourceMode
 } from "../../../data/repository/libraryRepository.js";
 import { mapWithConcurrency } from "../../../core/network/mapWithConcurrency.js";
+import { filterReleasedItems } from "../../../core/util/releaseInfoUtils.js";
 import { LayoutPreferences } from "../../../data/local/layoutPreferences.js";
 import { ContinueWatchingPreferences } from "../../../data/local/continueWatchingPreferences.js";
 import { HomeCatalogStore } from "../../../data/local/homeCatalogStore.js";
@@ -8678,6 +8679,24 @@ export const HomeScreen = {
     return this.heroCandidates[0] || this.pickHeroItem(this.rows);
   },
 
+  filterUnreleasedResult(result) {
+    if (
+      !this.layoutPrefs?.hideUnreleasedContent ||
+      result?.status !== "success"
+    ) {
+      return result;
+    }
+    const items = result.data?.items;
+    if (!Array.isArray(items)) {
+      return result;
+    }
+    const filtered = filterReleasedItems(items);
+    if (filtered === items) {
+      return result;
+    }
+    return { ...result, data: { ...result.data, items: filtered } };
+  },
+
   async fetchCatalogRows(descriptors = [], options = {}) {
     const allowLoading = Boolean(options?.allowLoading);
     const timeoutMs = Number(options?.timeoutMs || HOME_ROW_TIMEOUT_MS);
@@ -8691,19 +8710,21 @@ export const HomeScreen = {
     const fetchBatch = async (batchDescriptors = []) => {
       const rowResults = await Promise.all(
         batchDescriptors.map(async (catalog) => {
-          const result = await withTimeout(
-            catalogRepository.getCatalog({
-              addonBaseUrl: catalog.addonBaseUrl,
-              addonId: catalog.addonId,
-              addonName: catalog.addonName,
-              catalogId: catalog.catalogId,
-              catalogName: catalog.catalogName,
-              type: catalog.type,
-              skip: 0,
-              supportsSkip: true
-            }),
-            timeoutMs,
-            { status: "error", message: "timeout" }
+          const result = this.filterUnreleasedResult(
+            await withTimeout(
+              catalogRepository.getCatalog({
+                addonBaseUrl: catalog.addonBaseUrl,
+                addonId: catalog.addonId,
+                addonName: catalog.addonName,
+                catalogId: catalog.catalogId,
+                catalogName: catalog.catalogName,
+                type: catalog.type,
+                skip: 0,
+                supportsSkip: true
+              }),
+              timeoutMs,
+              { status: "error", message: "timeout" }
+            )
           );
           const rowKey = buildModernRowKey(catalog);
           const row = {
@@ -8806,19 +8827,21 @@ export const HomeScreen = {
         const batch = pendingRows.slice(index, index + retryBatchSize);
         const settled = await Promise.allSettled(
           batch.map(async (row) => {
-            const result = await withTimeout(
-              catalogRepository.getCatalog({
-                addonBaseUrl: row.addonBaseUrl,
-                addonId: row.addonId,
-                addonName: row.addonName,
-                catalogId: row.catalogId,
-                catalogName: row.catalogName,
-                type: row.type,
-                skip: 0,
-                supportsSkip: true
-              }),
-              HOME_ROW_RETRY_TIMEOUT_MS,
-              { status: "error", message: "timeout" }
+            const result = this.filterUnreleasedResult(
+              await withTimeout(
+                catalogRepository.getCatalog({
+                  addonBaseUrl: row.addonBaseUrl,
+                  addonId: row.addonId,
+                  addonName: row.addonName,
+                  catalogId: row.catalogId,
+                  catalogName: row.catalogName,
+                  type: row.type,
+                  skip: 0,
+                  supportsSkip: true
+                }),
+                HOME_ROW_RETRY_TIMEOUT_MS,
+                { status: "error", message: "timeout" }
+              )
             );
             if (result?.status !== "success") {
               return null;

--- a/js/ui/screens/search/searchScreen.js
+++ b/js/ui/screens/search/searchScreen.js
@@ -31,6 +31,7 @@ import {
   renderTitleWatchedBadge
 } from "../../components/watchedTitleBadge.js";
 import { renderLoadingIndicator } from "../../components/loadingIndicator.js";
+import { filterReleasedItems } from "../../../core/util/releaseInfoUtils.js";
 import {
   buildSearchScheduleIndices,
   buildSearchTargets,
@@ -712,7 +713,10 @@ export const SearchScreen = {
       responses
         .filter(({ result } = {}) => result?.status === "success" && result?.data?.items?.length)
         .map(({ catalog, result }) => {
-          const items = result?.data?.items || [];
+          const rawItems = result?.data?.items || [];
+          const items = this.layoutPrefs?.hideUnreleasedContent
+            ? filterReleasedItems(rawItems)
+            : rawItems;
           return {
             title: formatCatalogRowTitle(
               catalog.catalogName,
@@ -733,7 +737,8 @@ export const SearchScreen = {
             hasMore: Boolean(items.length > itemLimit || result?.data?.hasMore),
             items: items.slice(0, itemLimit)
           };
-        });
+        })
+        .filter((row) => row.items.length);
 
     const publishFirstResults = () => {
       if (


### PR DESCRIPTION
The layout setting to hide unreleased content already had a toggle and synced, but nothing in the app read it, so turning it on did nothing.

This wires it up on home and search. When the setting is on, catalog items that are not out yet get dropped, the same way the Android app does it. Rows that end up empty are hidden.

The filter logic is ported from the Android app's ReleaseInfoUtils and comes with unit tests that mirror the Android ones. It is off by default, so nothing changes unless you turn it on.

Verified in a browser with a mock addon serving one released and one unreleased item: with the setting off both show on home and search, with it on the unreleased one is gone. Also checked that on main the setting still does nothing, which confirms the bug.