### PR TITLE
fix(collections): keep focus stable while rows load

### DIFF
--- a/js/ui/screens/collection/folderDetailScreen.js
+++ b/js/ui/screens/collection/folderDetailScreen.js
@@ -34,6 +34,8 @@ const TMDB_API_URL = "https://api.themoviedb.org/3";
 const TMDB_POSTER_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w342";
 const TMDB_BACKDROP_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w1280";
 const TRAKT_PAGE_SIZE = 50;
+const FOLDER_LOADING_ROW_ITEM_COUNT = 6;
+const FOLDER_SOURCE_RENDER_BATCH_MS = 180;
 const STREAMING_NETWORK_PRESETS = new Map([
   ["netflix", { title: "Netflix", tmdbId: 213 }],
   ["hbo", { title: "HBO", tmdbId: 49 }],
@@ -205,8 +207,9 @@ function buildFolderSourceRows(tabs = []) {
     .map((tab, index) => {
       const sourceTabIndex = tabs.indexOf(tab);
       const type = sourceType(tab.source || {});
+      const rowKey = tab.key || `folder_source_${index}`;
       return {
-        homeCatalogKey: tab.key || `folder_source_${index}`,
+        homeCatalogKey: rowKey,
         folderTabIndex: sourceTabIndex >= 0 ? sourceTabIndex : index,
         addonId: tab.source?.addonId || tab.source?.provider || "collection",
         addonBaseUrl: tab.source?.addonBaseUrl || "",
@@ -225,6 +228,13 @@ function buildFolderSourceRows(tabs = []) {
             items: Array.isArray(tab.items) ? tab.items : []
           }
         },
+        loadingItems: tab.loading
+          ? Array.from({ length: FOLDER_LOADING_ROW_ITEM_COUNT }, (_, loadingIndex) => ({
+              id: `${rowKey}__loading_${loadingIndex}`,
+              name: "Loading",
+              isLoading: true
+            }))
+          : null,
         suppressPosterText: true
       };
     });
@@ -744,6 +754,26 @@ export const FolderDetailScreen = {
     return `folderDetail:${collectionId}:${folderId}`;
   },
 
+  cancelScheduledRender() {
+    if (this.folderDetailRenderTimer) {
+      clearTimeout(this.folderDetailRenderTimer);
+      this.folderDetailRenderTimer = null;
+    }
+  },
+
+  scheduleRender() {
+    if (this.folderDetailRenderTimer || !this.container || Router.getCurrent() !== "folderDetail") {
+      return;
+    }
+    this.folderDetailRenderTimer = setTimeout(() => {
+      this.folderDetailRenderTimer = null;
+      if (!this.container || Router.getCurrent() !== "folderDetail") {
+        return;
+      }
+      this.render();
+    }, FOLDER_SOURCE_RENDER_BATCH_MS);
+  },
+
   captureRouteState() {
     const shell = this.container?.querySelector(".seeall-shell");
     const active =
@@ -838,6 +868,7 @@ export const FolderDetailScreen = {
 
   async mount(params = {}, navigationContext = {}) {
     this.container = document.getElementById("folderDetail");
+    this.cancelScheduledRender();
     ScreenUtils.show(this.container);
     this.params = params || {};
     this.layoutPrefs = LayoutPreferences.get();
@@ -855,6 +886,9 @@ export const FolderDetailScreen = {
     this.restoredTrackScrollStates = {};
     this.restoredFollowLayoutFocusState = null;
     this.restoredFocusedItem = null;
+    this.isRestoringFocusFromBack = false;
+    this.homeHoldFocusLocked = false;
+    this.lastMainFocus = null;
     this.navModel = { rows: [] };
     this.tabs = [];
     const preferredHomeLayout = String(this.layoutPrefs?.homeLayout || "classic").toLowerCase();
@@ -936,7 +970,6 @@ export const FolderDetailScreen = {
         : sourceTabs;
 
     const restored = this.hydrateFromRouteState(navigationContext?.restoredState, this.params);
-    this.render();
     const sourceOffset = this.tabs[0]?.isAllTab ? 1 : 0;
     const tabsToLoad = restored
       ? this.tabs
@@ -944,7 +977,19 @@ export const FolderDetailScreen = {
           .filter(({ tab }) => !tab.isAllTab && tab.restoreNeedsReload)
           .map(({ index }) => index)
       : sourceTabs.map((_, index) => index + sourceOffset);
-    await Promise.all(tabsToLoad.map((index) => this.loadTab(index, { append: false })));
+    tabsToLoad.forEach((index) => {
+      const tab = this.tabs[index];
+      if (tab && !tab.isAllTab) {
+        this.tabs[index] = { ...tab, loading: true, error: "" };
+      }
+    });
+    this.sourceTabs = this.tabs.filter((tab) => !tab.isAllTab);
+    this.rebuildAllTab();
+    this.render();
+    await Promise.all(tabsToLoad.map((index) => this.loadTab(index, { background: true })));
+    if (tabsToLoad.length && Router.getCurrent() === "folderDetail") {
+      this.render();
+    }
   },
 
   rebuildAllTab() {
@@ -961,14 +1006,16 @@ export const FolderDetailScreen = {
     };
   },
 
-  async loadTab(tabIndex, { append = false } = {}) {
+  async loadTab(tabIndex, { append = false, background = false } = {}) {
     const tab = this.tabs[tabIndex];
-    if (!tab || tab.isAllTab || tab.loading) {
+    if (!tab || tab.isAllTab || (tab.loading && !background)) {
       return;
     }
-    this.tabs[tabIndex] = { ...tab, loading: true, error: "" };
-    this.rebuildAllTab();
-    this.render();
+    if (!background) {
+      this.tabs[tabIndex] = { ...tab, loading: true, error: "" };
+      this.rebuildAllTab();
+      this.render();
+    }
     try {
       const nextPage = append ? Math.max(1, Number(tab.page || 1) + 1) : 1;
       const result = await fetchSourceItems(tab.source, nextPage);
@@ -1001,7 +1048,11 @@ export const FolderDetailScreen = {
       };
     }
     this.rebuildAllTab();
-    this.render();
+    if (background) {
+      this.scheduleRender();
+    } else {
+      this.render();
+    }
   },
 
   getSelectedTab() {
@@ -1165,7 +1216,7 @@ export const FolderDetailScreen = {
       }
       if (
         this.restoredFollowLayoutFocusState &&
-        HomeScreen.restoreFocusState.call(this, this.restoredFollowLayoutFocusState)
+        HomeScreen.restoreModernFocusState.call(this, this.restoredFollowLayoutFocusState)
       ) {
         this.restoredFollowLayoutFocusState = null;
         return;
@@ -1237,6 +1288,7 @@ export const FolderDetailScreen = {
   },
 
   render() {
+    this.cancelScheduledRender();
     if (this.useHomeFollowLayout) {
       this.renderFollowLayout();
       return;
@@ -1427,6 +1479,10 @@ export const FolderDetailScreen = {
   },
 
   renderFollowLayout() {
+    this.renderedLayoutMode = "modern";
+    // Catalog sources resolve independently. Preserve the live TV-navigation state
+    // before replacing the layout so an arriving row cannot send focus to the top.
+    const liveFocusState = HomeScreen.captureCurrentContentFocusState.call(this);
     HomeScreen.cancelModernCameraFollow.call(this, { stopAnimations: true });
     HomeScreen.teardownModernTrackScrollPagination.call(this);
     HomeScreen.cancelFocusedPosterFlow.call(this);
@@ -1492,7 +1548,11 @@ export const FolderDetailScreen = {
         )
       );
     }
-    this.restoreFocus();
+    const restoredLiveFocus =
+      liveFocusState && HomeScreen.restoreModernFocusState.call(this, liveFocusState);
+    if (!restoredLiveFocus) {
+      this.restoreFocus();
+    }
     this.setupModernTrackScrollPagination();
     HomeScreen.applyHeroToDom.call(this);
     HomeScreen.ensureHomeTruncationObservers.call(this);
@@ -1914,6 +1974,7 @@ export const FolderDetailScreen = {
   },
 
   cleanup() {
+    this.cancelScheduledRender();
     if (this.useHomeFollowLayout) {
       HomeScreen.cancelModernCameraFollow.call(this, { stopAnimations: true });
       HomeScreen.stopHeroRotation.call(this);


### PR DESCRIPTION
## Summary

Seed stable pending rows, batch background collection-source renders, and preserve live TV focus/scroll state when a `FOLLOW_LAYOUT` collection folder is rebuilt.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Folders with 30 or more sources started every request with an immediate full-screen render and rendered again after every response. In `FOLLOW_LAYOUT`, each render replaces the complete DOM. The old focused node therefore disappeared and focus restoration fell back to the first row, making Down navigation laggy or unusable on LG webOS while rows loaded.

## Issue or approval

Fixes #687

## Reproduction steps

1. Import a collection containing a `FOLLOW_LAYOUT` folder with 30 or more catalog sources.
2. Open the collection folder.
3. Press Down repeatedly while source rows are still loading.
4. Observe focus as late catalog responses add rows.

## Old behavior

Each of 30 source starts and completions could rebuild the entire screen. While navigating downward, an arriving response could reset focus and vertical position toward row 1.

## New behavior

- Initial background source loads do not render once per request start.
- All pending sources have fixed-height skeleton rows from the first render, so row geometry does not grow from 0 to 30 while loading.
- Response-driven renders are batched to at most one scheduled render per 180 ms, with a final flush.
- Before an unavoidable `FOLLOW_LAYOUT` DOM replacement, the current focused row/item plus vertical and horizontal scroll positions are captured and restored.
- Folder-specific focus state is isolated from the shared Home screen prototype, including when Home last rendered Classic or Grid.
- Scheduled work is cancelled when leaving the screen.

## Platform impact

- Samsung Tizen: Shared code path benefits, but not device-tested.
- LG webOS: Reported affected platform; removes repeated focus resets and reduces render pressure.
- Browser development mode: Deterministic 30-row reproduction tested in Chrome on macOS.
- Installer / packaging: No impact.
- Wrapper repositories: No impact.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [x] No playback change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No styling, collection schema, addon networking, playback, packaging, or unrelated navigation behavior changes. Real collection row contents remain unchanged; skeleton rows exist only while their corresponding source is pending.

## Testing

### Devices / platforms tested

- Chrome on macOS, local development build with deterministic delayed catalogs.
- LG webOS is the reported platform; no physical LG device was available for this test.

### Commands tested

```sh
node --check js/ui/screens/collection/folderDetailScreen.js
npx eslint js/ui/screens/collection/folderDetailScreen.js
npm test
npm run build
```

All commands above passed. `npm run format:check` remains blocked by 32 pre-existing formatting failures on `main`; unrelated files were deliberately not reformatted.

## Manual test flow

The supplied 30-source Netflix collection was remapped to deterministic local catalogs with staggered response delays and 12 cards per row. The flow was repeated after Home rendered in Modern, Classic, and Grid modes:

- Confirmed that all 30 rows and 180 non-focusable skeleton cards were present before any source completed.
- Navigated down to `Row 7 Item 1` while sources were still pending.
- Waited for all 30 rows / 360 cards to finish loading.
- Focus remained on `Row 7 Item 1` in Modern, Classic, and Grid preference cases; the final retained vertical scroll position was `2502`.
- All 30 catalog requests completed without console/network errors.

## Screenshots / Video

This is a motion/focus timing bug, so static screenshots do not demonstrate the failure. The before/after deterministic focus trace is included in the manual test flow above. A physical-TV recording was not available.

## Logs

Not applicable. The bug reproduces with successful catalog responses and no errors.

## Regression risk

Low. Changes are limited to collection-folder rendering. Interactive pagination keeps its immediate render path; only initial background loads are batched. Focus restoration uses the existing Home focus-state helpers, but folder-owned state prevents Home layout preferences from leaking into restoration.

## Breaking changes

None.

## Linked issues

Fixes #687
