### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,11 +290,11 @@ For comprehensive legal information, including our full disclaimer, third-party 
 
 ## Star History
 
-<a href="https://www.star-history.com/#NuvioMedia/NuvioWeb&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#NuvioMedia/NuvioWeb&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=NuvioMedia/NuvioWeb&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=NuvioMedia/NuvioWeb&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=NuvioMedia/NuvioWeb&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=NuvioMedia/NuvioWeb&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=NuvioMedia/NuvioWeb&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=NuvioMedia/NuvioWeb&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken and does not render. This change points it at a working mirror so the chart displays correctly again.