### PR TITLE
Add overall ratings visibility setting

### DIFF
--- a/js/core/profile/profileSettingsSyncService.js
+++ b/js/core/profile/profileSettingsSyncService.js
@@ -746,6 +746,9 @@ const FEATURE_ADAPTERS = {
         continue_watching_sort_mode: normalizeContinueWatchingSortModeForAndroid(
           layout.continueWatchingSortMode
         ),
+        home_imdb_ratings_visibility: String(
+          layout.homeImdbRatingsVisibility || "SHOW_ALL"
+        ).toUpperCase(),
         fast_horizontal_navigation_enabled: isFastHorizontalNavigationEnabled()
       };
     },
@@ -845,6 +848,13 @@ const FEATURE_ADAPTERS = {
         projected.fast_horizontal_navigation_enabled = Boolean(
           raw.fast_horizontal_navigation_enabled
         );
+      }
+      if (stringOrNull(raw.home_imdb_ratings_visibility)) {
+        projected.home_imdb_ratings_visibility = String(
+          raw.home_imdb_ratings_visibility
+        )
+          .trim()
+          .toUpperCase();
       }
       return projected;
     },
@@ -979,6 +989,11 @@ const FEATURE_ADAPTERS = {
         partial.continueWatchingSortMode = normalizeContinueWatchingSortModeForWeb(
           raw.continue_watching_sort_mode
         );
+      }
+      if (stringOrNull(raw.home_imdb_ratings_visibility)) {
+        partial.homeImdbRatingsVisibility = String(raw.home_imdb_ratings_visibility)
+          .trim()
+          .toUpperCase();
       }
       if (!Object.keys(partial).length) {
         return false;

--- a/js/core/profile/profileSettingsSyncService.js
+++ b/js/core/profile/profileSettingsSyncService.js
@@ -850,9 +850,7 @@ const FEATURE_ADAPTERS = {
         );
       }
       if (stringOrNull(raw.home_imdb_ratings_visibility)) {
-        projected.home_imdb_ratings_visibility = String(
-          raw.home_imdb_ratings_visibility
-        )
+        projected.home_imdb_ratings_visibility = String(raw.home_imdb_ratings_visibility)
           .trim()
           .toUpperCase();
       }

--- a/js/core/util/imdbRatingVisibility.js
+++ b/js/core/util/imdbRatingVisibility.js
@@ -1,0 +1,28 @@
+// Ported from Android NuvioTV domain/model/ImdbRatingVisibility.kt so the web app
+// applies the same IMDB rating visibility rules.
+//
+// The home setting controls home ratings and the standard title rating shown on
+// the detail screen. An active MDBList rating always takes priority over the
+// standard detail rating.
+
+export const HOME_IMDB_RATINGS_VISIBILITY = {
+  SHOW_ALL: "SHOW_ALL",
+  HIDE_ALL: "HIDE_ALL"
+};
+
+export function normalizeHomeImdbRatingsVisibility(value) {
+  return value === HOME_IMDB_RATINGS_VISIBILITY.HIDE_ALL
+    ? HOME_IMDB_RATINGS_VISIBILITY.HIDE_ALL
+    : HOME_IMDB_RATINGS_VISIBILITY.SHOW_ALL;
+}
+
+// Home rows and hero ratings.
+export function showHomeRatings(visibility) {
+  return normalizeHomeImdbRatingsVisibility(visibility) === HOME_IMDB_RATINGS_VISIBILITY.SHOW_ALL;
+}
+
+// Standard title rating on the detail screen. An active MDBList rating takes
+// priority and always hides the standard rating.
+export function showStandardDetailRatings(visibility, isMdbListActive) {
+  return showHomeRatings(visibility) && !isMdbListActive;
+}

--- a/js/core/util/imdbRatingVisibility.test.mjs
+++ b/js/core/util/imdbRatingVisibility.test.mjs
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  HOME_IMDB_RATINGS_VISIBILITY,
+  normalizeHomeImdbRatingsVisibility,
+  showHomeRatings,
+  showStandardDetailRatings
+} from "./imdbRatingVisibility.js";
+
+test("overall visibility controls home and standard detail ratings", () => {
+  assert.equal(showHomeRatings(HOME_IMDB_RATINGS_VISIBILITY.SHOW_ALL), true);
+  assert.equal(showHomeRatings(HOME_IMDB_RATINGS_VISIBILITY.HIDE_ALL), false);
+
+  assert.equal(showStandardDetailRatings(HOME_IMDB_RATINGS_VISIBILITY.SHOW_ALL, false), true);
+  assert.equal(showStandardDetailRatings(HOME_IMDB_RATINGS_VISIBILITY.HIDE_ALL, false), false);
+});
+
+test("active mdblist takes priority over overall detail visibility", () => {
+  assert.equal(showStandardDetailRatings(HOME_IMDB_RATINGS_VISIBILITY.SHOW_ALL, true), false);
+  assert.equal(showStandardDetailRatings(HOME_IMDB_RATINGS_VISIBILITY.HIDE_ALL, true), false);
+});
+
+test("unknown or missing values fall back to showing ratings", () => {
+  assert.equal(
+    normalizeHomeImdbRatingsVisibility(undefined),
+    HOME_IMDB_RATINGS_VISIBILITY.SHOW_ALL
+  );
+  assert.equal(
+    normalizeHomeImdbRatingsVisibility("nonsense"),
+    HOME_IMDB_RATINGS_VISIBILITY.SHOW_ALL
+  );
+  assert.equal(
+    normalizeHomeImdbRatingsVisibility(HOME_IMDB_RATINGS_VISIBILITY.HIDE_ALL),
+    HOME_IMDB_RATINGS_VISIBILITY.HIDE_ALL
+  );
+  assert.equal(showHomeRatings("nonsense"), true);
+});

--- a/js/data/local/layoutPreferences.js
+++ b/js/data/local/layoutPreferences.js
@@ -1,5 +1,6 @@
 import { createProfileScopedStore } from "./profileScopedStore.js";
 import { LocalStore } from "../../core/storage/localStore.js";
+import { normalizeHomeImdbRatingsVisibility } from "../../core/util/imdbRatingVisibility.js";
 
 const KEY = "layoutPreferences";
 
@@ -45,7 +46,8 @@ const DEFAULTS = {
   blurContinueWatchingNextUp: false,
   showUnairedNextUp: true,
   nextUpFromFurthestEpisode: true,
-  continueWatchingSortMode: "default"
+  continueWatchingSortMode: "default",
+  homeImdbRatingsVisibility: "SHOW_ALL"
 };
 
 function normalizeContinueWatchingSortMode(value) {
@@ -129,6 +131,7 @@ function normalizeLayoutPreferences(value = {}) {
     showUnairedNextUp: merged.showUnairedNextUp !== false,
     nextUpFromFurthestEpisode: merged.nextUpFromFurthestEpisode !== false,
     continueWatchingSortMode: normalizeContinueWatchingSortMode(merged.continueWatchingSortMode),
+    homeImdbRatingsVisibility: normalizeHomeImdbRatingsVisibility(merged.homeImdbRatingsVisibility),
     collapseSidebar: modernSidebar ? false : Boolean(merged.collapseSidebar),
     modernSidebar,
     modernSidebarBlur: modernSidebar

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -10,6 +10,10 @@ import { watchedSeriesReconciliationService } from "../../../data/repository/wat
 import { TmdbService } from "../../../core/tmdb/tmdbService.js";
 import { TmdbMetadataService } from "../../../core/tmdb/tmdbMetadataService.js";
 import { LayoutPreferences } from "../../../data/local/layoutPreferences.js";
+import {
+  showHomeRatings,
+  showStandardDetailRatings
+} from "../../../core/util/imdbRatingVisibility.js";
 import { imdbEpisodeRatingsRepository } from "../../../data/repository/imdbEpisodeRatingsRepository.js";
 import { normalizeEpisodeImdbRating, parseEpisodeRuntimeMinutes } from "./episodeCardMetadata.js";
 import { mdbListRepository } from "../../../data/repository/mdbListRepository.js";
@@ -3205,7 +3209,13 @@ export const MetaDetailsScreen = {
     const primaryParts = [
       genresText ? `<span>${escapeHtml(genresText)}</span>` : "",
       yearText ? `<span>${escapeHtml(yearText)}</span>` : "",
-      imdbText && !hasExternalRatings ? renderImdbBadge(imdbText) : ""
+      imdbText &&
+      showStandardDetailRatings(
+        LayoutPreferences.get().homeImdbRatingsVisibility,
+        hasExternalRatings
+      )
+        ? renderImdbBadge(imdbText)
+        : ""
     ].filter(Boolean);
     const secondaryParts = [];
     if (ageRating && status) {
@@ -3510,9 +3520,10 @@ export const MetaDetailsScreen = {
   },
   renderMovieInsightSection(meta) {
     const trailerItems = resolveTrailerItems(meta);
+    const showRatings = showHomeRatings(LayoutPreferences.get().homeImdbRatingsVisibility);
     const tabItems = [
       ["cast", t("detail.creatorCast", {}, "Creator and Cast")],
-      ["ratings", t("detail.ratings", {}, "Ratings")],
+      ...(showRatings ? [["ratings", t("detail.ratings", {}, "Ratings")]] : []),
       ...(this.moreLikeThisItems.length
         ? [["morelike", t("detail.moreLikeThis", {}, "More Like This")]]
         : []),
@@ -3521,7 +3532,7 @@ export const MetaDetailsScreen = {
     ];
     const tabs =
       tabItems.length > 1 ? this.renderPeopleTabs("movie", this.movieInsightTab, tabItems) : "";
-    if (this.movieInsightTab === "ratings") {
+    if (this.movieInsightTab === "ratings" && showRatings) {
       const imdbValue = resolveImdbRating(meta);
       const imdb = imdbValue != null && String(imdbValue).trim() !== "" ? String(imdbValue) : "-";
       const tmdb = Number.isFinite(Number(meta?.tmdbRating)) ? String(meta.tmdbRating) : "-";

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -13,6 +13,7 @@ import {
 import { mapWithConcurrency } from "../../../core/network/mapWithConcurrency.js";
 import { filterReleasedItems } from "../../../core/util/releaseInfoUtils.js";
 import { LayoutPreferences } from "../../../data/local/layoutPreferences.js";
+import { showHomeRatings } from "../../../core/util/imdbRatingVisibility.js";
 import { ContinueWatchingPreferences } from "../../../data/local/continueWatchingPreferences.js";
 import { HomeCatalogStore } from "../../../data/local/homeCatalogStore.js";
 import { CollectionsStore, buildCollectionHomeKey } from "../../../data/local/collectionsStore.js";
@@ -1882,6 +1883,10 @@ function buildHeroIdentity(item = null) {
   ].join("|");
 }
 
+function hideHomeHeroRatings() {
+  return !showHomeRatings(LayoutPreferences.get()?.homeImdbRatingsVisibility);
+}
+
 /**
  * @param {HomeMediaSourceLike | null | undefined} hero
  * @param {string} layoutMode
@@ -1907,7 +1912,7 @@ function buildHeroDisplayModel(hero, layoutMode) {
     };
   }
   const year = extractYear(hero);
-  const imdb = resolveImdbRating(hero);
+  const imdb = hideHomeHeroRatings() ? null : resolveImdbRating(hero);
   const genres = Array.isArray(hero?.genres) ? hero.genres.filter(Boolean).slice(0, 3) : [];
   const typeLabel = formatContentTypeLabel(hero?.type || hero?.apiType || "movie", "movie");
   const isContinueWatchingHero = hero?.heroSource === "continueWatching";
@@ -1994,7 +1999,7 @@ export function buildModernHeroPresentation(hero) {
   );
   const runtimeText = formatRuntimeText(normalized);
   const yearText = extractReleaseDateText(normalized);
-  const imdbText = resolveImdbRating(normalized);
+  const imdbText = hideHomeHeroRatings() ? "" : resolveImdbRating(normalized);
   const statusBadge = firstNonEmpty(normalized.status).toUpperCase();
   const ageRatingBadge = firstNonEmpty(normalized.ageRating);
   const languageText = firstNonEmpty(normalized.language).toUpperCase();

--- a/js/ui/screens/settings/settingsScreen.js
+++ b/js/ui/screens/settings/settingsScreen.js
@@ -3711,6 +3711,12 @@ export const SettingsScreen = {
         }
       });
     });
+    this.actionMap.set("layout:homeImdbRatings", () => {
+      const current = LayoutPreferences.get().homeImdbRatingsVisibility;
+      LayoutPreferences.set({
+        homeImdbRatingsVisibility: current === "HIDE_ALL" ? "SHOW_ALL" : "HIDE_ALL"
+      });
+    });
     this.actionMap.set("layout:posterLabels", () => {
       LayoutPreferences.set({ posterLabelsEnabled: !LayoutPreferences.get().posterLabelsEnabled });
     });
@@ -3810,6 +3816,7 @@ export const SettingsScreen = {
         : continueWatchingSortMode === "streaming_style"
           ? t("settings.layout.continueWatchingSort.streamingStyle", {}, "Streaming Style")
           : t("settings.layout.continueWatchingSort.default", {}, "Default");
+    const homeRatingsShown = model.layout.homeImdbRatingsVisibility !== "HIDE_ALL";
 
     const homeLayoutBody = `
       <div class="settings-stack">
@@ -3962,6 +3969,18 @@ export const SettingsScreen = {
           title: t("settings.layout.hideUnreleased.title"),
           subtitle: t("settings.layout.hideUnreleased.subtitle"),
           checked: Boolean(model.layout.hideUnreleasedContent)
+        })}
+        ${this.renderToggleRow({
+          focusKey: "layout:homeImdbRatings",
+          title: t("layout_overall_ratings", {}, "Overall Ratings"),
+          subtitle: homeRatingsShown
+            ? t("layout_overall_ratings_sub_on", {}, "Standard and TMDB ratings are shown.")
+            : t(
+                "layout_overall_ratings_sub_off",
+                {},
+                "Standard and TMDB ratings are Hidden. MDBList provider settings take priority on detail pages."
+              ),
+          checked: homeRatingsShown
         })}
       </div>
     `;

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -1829,4 +1829,7 @@
     <string name="cloud_library_error_provider_unavailable">المكتبة السحابية غير متوفرة لـ %1$s.</string>
     <string name="cloud_library_error_disabled">المكتبة السحابية معطلة.</string>
     <string name="cloud_library_search_clear">مسح البحث</string>
+    <string name="layout_overall_ratings">التقييمات العامة</string>
+    <string name="layout_overall_ratings_sub_on">يتم عرض التقييمات القياسية وتقييمات TMDB.</string>
+    <string name="layout_overall_ratings_sub_off">التقييمات القياسية وتقييمات TMDB مخفية. تكون إعدادات مزود MDBList لها الأولوية في صفحات التفاصيل.</string>
 </resources>

--- a/res/values-bs/strings.xml
+++ b/res/values-bs/strings.xml
@@ -1629,4 +1629,7 @@
     <string name="cloud_library_error_provider_unavailable">Cloud biblioteka nije dostupna za %1$s.</string>
     <string name="cloud_library_error_disabled">Cloud biblioteka je onemogućena.</string>
     <string name="cloud_library_search_clear">Obriši pretragu</string>
+    <string name="layout_overall_ratings">Ukupne ocjene</string>
+    <string name="layout_overall_ratings_sub_on">Standardne i TMDB ocjene su prikazane.</string>
+    <string name="layout_overall_ratings_sub_off">Standardne i TMDB ocjene su skrivene. Postavke provajdera MDBList imaju prednost na stranicama s detaljima.</string>
 </resources>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -2261,4 +2261,7 @@
     <string name="cloud_library_error_provider_unavailable">Cloudová knihovna není pro %1$s dostupná.</string>
     <string name="cloud_library_error_disabled">Cloudová knihovna je vypnutá.</string>
     <string name="cloud_library_search_clear">Vymazat vyhledávání</string>
+    <string name="layout_overall_ratings">Celkové hodnocení</string>
+    <string name="layout_overall_ratings_sub_on">Zobrazují se standardní hodnocení a hodnocení TMDB.</string>
+    <string name="layout_overall_ratings_sub_off">Standardní hodnocení a hodnocení TMDB jsou skryta. Nastavení poskytovatele MDBList mají na stránkách s podrobnostmi přednost.</string>
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -2333,4 +2333,7 @@
     <string name="cloud_library_error_provider_unavailable">Die Cloud-Bibliothek ist für %1$s nicht verfügbar.</string>
     <string name="cloud_library_error_disabled">Die Cloud-Bibliothek ist deaktiviert.</string>
     <string name="cloud_library_search_clear">Suche löschen</string>
+    <string name="layout_overall_ratings">Gesamtbewertungen</string>
+    <string name="layout_overall_ratings_sub_on">Standard- und TMDB-Bewertungen werden angezeigt.</string>
+    <string name="layout_overall_ratings_sub_off">Standard- und TMDB-Bewertungen sind ausgeblendet. Die Einstellungen des MDBList-Anbieters haben auf Detailseiten Vorrang.</string>
 </resources>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -2562,4 +2562,7 @@
     <string name="cloud_library_error_disabled">Η cloud βιβλιοθήκη είναι απενεργοποιημένη.</string>
     <string name="cloud_library_search_clear">Εκκαθάριση αναζήτησης</string>
     <string name="upcoming_section_title">Επόμενα</string>
+    <string name="layout_overall_ratings">Συνολικές βαθμολογίες</string>
+    <string name="layout_overall_ratings_sub_on">Οι τυπικές βαθμολογίες και οι βαθμολογίες TMDB εμφανίζονται.</string>
+    <string name="layout_overall_ratings_sub_off">Οι τυπικές βαθμολογίες και οι βαθμολογίες TMDB είναι κρυφές. Οι ρυθμίσεις παρόχου MDBList έχουν προτεραιότητα στις σελίδες λεπτομερειών.</string>
 </resources>

--- a/res/values-es-419/strings.xml
+++ b/res/values-es-419/strings.xml
@@ -2458,4 +2458,7 @@
     <string name="layout_cw_sort_split_upcoming">Separar fila de próximos</string>
     <string name="layout_cw_sort_split_upcoming_desc">Mueve los episodios que aún no se han emitido a una fila separada de Próximos</string>
     <string name="upcoming_section_title">Próximos</string>
+    <string name="layout_overall_ratings">Calificaciones generales</string>
+    <string name="layout_overall_ratings_sub_on">Se muestran las calificaciones estándar y de TMDB.</string>
+    <string name="layout_overall_ratings_sub_off">Las calificaciones estándar y de TMDB están ocultas. La configuración del proveedor MDBList tiene prioridad en las páginas de detalles.</string>
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -1351,4 +1351,7 @@
     <string name="cloud_library_error_provider_unavailable">La biblioteca en la nube no está disponible para %1$s.</string>
     <string name="cloud_library_error_disabled">La biblioteca en la nube está deshabilitada.</string>
     <string name="cloud_library_search_clear">Borrar búsqueda</string>
+    <string name="layout_overall_ratings">Calificaciones generales</string>
+    <string name="layout_overall_ratings_sub_on">Se muestran las calificaciones estándar y de TMDB.</string>
+    <string name="layout_overall_ratings_sub_off">Las calificaciones estándar y de TMDB están ocultas. La configuración del proveedor MDBList tiene prioridad en las páginas de detalles.</string>
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -2607,4 +2607,7 @@
     <string name="cloud_library_search_label">Rechercher dans la bibliothèque cloud</string>
     <string name="cloud_library_search_placeholder">Rechercher des fichiers</string>
     <string name="cloud_library_search_clear">Effacer la recherche</string>
+    <string name="layout_overall_ratings">Notes globales</string>
+    <string name="layout_overall_ratings_sub_on">Les notes standard et TMDB sont affichées.</string>
+    <string name="layout_overall_ratings_sub_off">Les notes standard et TMDB sont masquées. Les paramètres du fournisseur MDBList sont prioritaires sur les pages de détails.</string>
 </resources>

--- a/res/values-he/strings.xml
+++ b/res/values-he/strings.xml
@@ -1567,4 +1567,7 @@
     <string name="cloud_library_error_disabled">ספריית הענן מושבתת.</string>
     <string name="cloud_library_search_clear">Clear search</string>
     <string name="upcoming_section_title">עתידי</string>
+    <string name="layout_overall_ratings">דירוגים כלליים</string>
+    <string name="layout_overall_ratings_sub_on">הדירוגים הרגילים ודירוגי TMDB מוצגים.</string>
+    <string name="layout_overall_ratings_sub_off">הדירוגים הרגילים ודירוגי TMDB מוסתרים. להגדרות ספק MDBList יש עדיפות בדפי הפרטים.</string>
 </resources>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -1302,4 +1302,7 @@
     <string name="cloud_library_error_provider_unavailable">%1$s के लिए क्लाउड लाइब्रेरी उपलब्ध नहीं है।</string>
     <string name="cloud_library_error_disabled">क्लाउड लाइब्रेरी अक्षम है.</string>
     <string name="cloud_library_search_clear">स्पष्ट खोज</string>
+    <string name="layout_overall_ratings">समग्र रेटिंग</string>
+    <string name="layout_overall_ratings_sub_on">मानक और TMDB रेटिंग दिखाई जाती हैं।</string>
+    <string name="layout_overall_ratings_sub_off">मानक और TMDB रेटिंग छिपी हुई हैं। विवरण पृष्ठों पर MDBList प्रदाता सेटिंग्स को प्राथमिकता दी जाती है।</string>
 </resources>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -1267,4 +1267,7 @@
     <string name="layout_cw_sort_split_upcoming">Külön Hamarosan sor</string>
     <string name="layout_cw_sort_split_upcoming_desc">A még le nem adott epizódok áthelyezése külön Hamarosan sorba</string>
     <string name="upcoming_section_title">Hamarosan</string>
+    <string name="layout_overall_ratings">Összesített értékelések</string>
+    <string name="layout_overall_ratings_sub_on">A standard és TMDB-értékelések megjelennek.</string>
+    <string name="layout_overall_ratings_sub_off">A standard és TMDB-értékelések rejtve vannak. A részletező oldalakon az MDBList-szolgáltató beállításai élveznek elsőbbséget.</string>
 </resources>

--- a/res/values-id/strings.xml
+++ b/res/values-id/strings.xml
@@ -2348,4 +2348,7 @@
     <string name="cloud_library_error_provider_unavailable">Pustaka cloud tidak tersedia untuk %1$s.</string>
     <string name="cloud_library_error_disabled">Perpustakaan awan dinonaktifkan.</string>
     <string name="cloud_library_search_clear">Hapus pencarian</string>
+    <string name="layout_overall_ratings">Rating Keseluruhan</string>
+    <string name="layout_overall_ratings_sub_on">Rating standar dan TMDB ditampilkan.</string>
+    <string name="layout_overall_ratings_sub_off">Rating standar dan TMDB disembunyikan. Pengaturan penyedia MDBList diprioritaskan di halaman detail.</string>
 </resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -2738,4 +2738,7 @@
     <string name="cloud_library_search_label">Cerca nella libreria cloud</string>
     <string name="cloud_library_search_placeholder">Cerca file</string>
     <string name="cloud_library_search_clear">Cancella ricerca</string>
+    <string name="layout_overall_ratings">Valutazioni complessive</string>
+    <string name="layout_overall_ratings_sub_on">Vengono mostrate le valutazioni standard e TMDB.</string>
+    <string name="layout_overall_ratings_sub_off">Le valutazioni standard e TMDB sono nascoste. Nelle pagine dei dettagli hanno la priorità le impostazioni del provider MDBList.</string>
 </resources>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -1774,4 +1774,7 @@
     <string name="cloud_library_error_provider_unavailable">%1$sのクラウドライブラリは利用できません。</string>
     <string name="cloud_library_error_disabled">クラウドライブラリは無効です。</string>
     <string name="cloud_library_search_clear">検索をクリア</string>
+    <string name="layout_overall_ratings">総合評価</string>
+    <string name="layout_overall_ratings_sub_on">標準評価とTMDBの評価を表示します。</string>
+    <string name="layout_overall_ratings_sub_off">標準評価とTMDBの評価は非表示です。詳細ページではMDBListプロバイダーの設定が優先されます。</string>
 </resources>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -1180,4 +1180,7 @@ Klaida: Bandomoji simuliuojama klaida — tai nėra tikras gedimas. Šaltinis gr
     <string name="cloud_library_error_provider_unavailable">Debesų biblioteka nepasiekiama %1$s.</string>
     <string name="cloud_library_error_disabled">Debesų biblioteka išjungta.</string>
     <string name="cloud_library_search_clear">Išvalyti paiešką</string>
+    <string name="layout_overall_ratings">Bendri įvertinimai</string>
+    <string name="layout_overall_ratings_sub_on">Rodomi standartiniai ir TMDB įvertinimai.</string>
+    <string name="layout_overall_ratings_sub_off">Standartiniai ir TMDB įvertinimai paslėpti. Išsamios informacijos puslapiuose pirmenybė teikiama MDBList teikėjo nustatymams.</string>
 </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -1178,4 +1178,7 @@
     <string name="cloud_library_error_provider_unavailable">Cloudbibliotheek is niet beschikbaar voor %1$s.</string>
     <string name="cloud_library_error_disabled">Cloudbibliotheek is uitgeschakeld.</string>
     <string name="cloud_library_search_clear">Duidelijke zoekopdracht</string>
+    <string name="layout_overall_ratings">Algemene beoordelingen</string>
+    <string name="layout_overall_ratings_sub_on">Standaard- en TMDB-beoordelingen worden weergegeven.</string>
+    <string name="layout_overall_ratings_sub_off">Standaard- en TMDB-beoordelingen zijn verborgen. Op detailpagina's hebben de instellingen van de MDBList-provider voorrang.</string>
 </resources>

--- a/res/values-no/strings.xml
+++ b/res/values-no/strings.xml
@@ -1293,4 +1293,7 @@
     <string name="cloud_library_error_provider_unavailable">Skybibliotek er ikke tilgjengelig for %1$s.</string>
     <string name="cloud_library_error_disabled">Skybiblioteket er deaktivert.</string>
     <string name="cloud_library_search_clear">Tøm søk</string>
+    <string name="layout_overall_ratings">Samlede vurderinger</string>
+    <string name="layout_overall_ratings_sub_on">Standard- og TMDB-vurderinger vises.</string>
+    <string name="layout_overall_ratings_sub_off">Standard- og TMDB-vurderinger er skjult. Innstillingene for MDBList-leverandøren har prioritet på detaljsider.</string>
 </resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -2707,4 +2707,7 @@
     <string name="cloud_library_search_placeholder">Wyszukaj pliki</string>
     <string name="cloud_library_search_clear">Wyczyść wyszukiwanie</string>
     <string name="upcoming_section_title">Nadchodzące</string>
+    <string name="layout_overall_ratings">Oceny ogólne</string>
+    <string name="layout_overall_ratings_sub_on">Wyświetlane są standardowe oceny oraz oceny TMDB.</string>
+    <string name="layout_overall_ratings_sub_off">Standardowe oceny oraz oceny TMDB są ukryte. Na stronach szczegółów priorytet mają ustawienia dostawcy MDBList.</string>
 </resources>

--- a/res/values-pt-br/strings.xml
+++ b/res/values-pt-br/strings.xml
@@ -2712,4 +2712,7 @@
     <string name="cloud_library_search_placeholder">Pesquisar arquivos</string>
     <string name="cloud_library_search_clear">Limpar pesquisa</string>
     <string name="upcoming_section_title">Próximos</string>
+    <string name="layout_overall_ratings">Avaliações gerais</string>
+    <string name="layout_overall_ratings_sub_on">As avaliações padrão e do TMDB são exibidas.</string>
+    <string name="layout_overall_ratings_sub_off">As avaliações padrão e do TMDB estão ocultas. As configurações do provedor MDBList têm prioridade nas páginas de detalhes.</string>
 </resources>

--- a/res/values-pt-pt/strings.xml
+++ b/res/values-pt-pt/strings.xml
@@ -2648,4 +2648,7 @@
     <string name="cloud_library_search_label">Pesquisar biblioteca na nuvem</string>
     <string name="cloud_library_search_placeholder">Pesquisar arquivos</string>
     <string name="cloud_library_search_clear">Limpar pesquisa</string>
+    <string name="layout_overall_ratings">Avaliações gerais</string>
+    <string name="layout_overall_ratings_sub_on">As avaliações padrão e do TMDB são apresentadas.</string>
+    <string name="layout_overall_ratings_sub_off">As avaliações padrão e do TMDB estão ocultas. As definições do fornecedor MDBList têm prioridade nas páginas de detalhes.</string>
 </resources>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -1022,4 +1022,7 @@
     <string name="cloud_library_error_provider_unavailable">Biblioteca cloud nu este disponibilă pentru %1$s.</string>
     <string name="cloud_library_error_disabled">Biblioteca cloud este dezactivată.</string>
     <string name="cloud_library_search_clear">Ștergeți căutarea</string>
+    <string name="layout_overall_ratings">Evaluări generale</string>
+    <string name="layout_overall_ratings_sub_on">Evaluările standard și TMDB sunt afișate.</string>
+    <string name="layout_overall_ratings_sub_off">Evaluările standard și TMDB sunt ascunse. Setările furnizorului MDBList au prioritate pe paginile de detalii.</string>
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -2387,4 +2387,7 @@
     <string name="cloud_library_search_label">Поиск в облачной библиотеке</string>
     <string name="cloud_library_search_placeholder">Поиск файлов</string>
     <string name="cloud_library_search_clear">Очистить поиск</string>
+    <string name="layout_overall_ratings">Общие оценки</string>
+    <string name="layout_overall_ratings_sub_on">Стандартные оценки и оценки TMDB отображаются.</string>
+    <string name="layout_overall_ratings_sub_off">Стандартные оценки и оценки TMDB скрыты. На страницах сведений приоритет имеют настройки провайдера MDBList.</string>
 </resources>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -2684,4 +2684,7 @@
     <string name="cloud_library_error_disabled">Cloudová knižnica je vypnutá.</string>
     <string name="cloud_library_search_clear">Vymazať vyhľadávanie</string>
     <string name="upcoming_section_title">Nespustené</string>
+    <string name="layout_overall_ratings">Celkové hodnotenia</string>
+    <string name="layout_overall_ratings_sub_on">Štandardné hodnotenia a hodnotenia TMDB sa zobrazujú.</string>
+    <string name="layout_overall_ratings_sub_off">Štandardné hodnotenia a hodnotenia TMDB sú skryté. Nastavenia poskytovateľa MDBList majú na stránkach s podrobnosťami prednosť.</string>
 </resources>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -2452,4 +2452,7 @@
     <string name="cloud_library_error_provider_unavailable">Knjižnica v oblaku ni na voljo za %1$s.</string>
     <string name="cloud_library_error_disabled">Knjižnica v oblaku je onemogočena.</string>
     <string name="cloud_library_search_clear">Počisti iskanje</string>
+    <string name="layout_overall_ratings">Skupne ocene</string>
+    <string name="layout_overall_ratings_sub_on">Standardne ocene in ocene TMDB so prikazane.</string>
+    <string name="layout_overall_ratings_sub_off">Standardne ocene in ocene TMDB so skrite. Nastavitve ponudnika MDBList imajo na straneh s podrobnostmi prednost.</string>
 </resources>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -1678,4 +1678,7 @@
     <string name="cloud_library_error_provider_unavailable">Molnbiblioteket är inte tillgängligt för %1$s.</string>
     <string name="cloud_library_error_disabled">Molnbiblioteket är inaktiverat.</string>
     <string name="cloud_library_search_clear">Rensa sökning</string>
+    <string name="layout_overall_ratings">Övergripande betyg</string>
+    <string name="layout_overall_ratings_sub_on">Standard- och TMDB-betyg visas.</string>
+    <string name="layout_overall_ratings_sub_off">Standard- och TMDB-betyg är dolda. Inställningarna för MDBList-leverantören har företräde på detaljsidor.</string>
 </resources>

--- a/res/values-ta/strings.xml
+++ b/res/values-ta/strings.xml
@@ -2336,4 +2336,7 @@
     <string name="cloud_library_error_provider_unavailable">%1$s க்கு கிளவுட் லைப்ரரி கிடைக்கவில்லை.</string>
     <string name="cloud_library_error_disabled">கிளவுட் லைப்ரரி முடக்கப்பட்டுள்ளது.</string>
     <string name="cloud_library_search_clear">தெளிவான தேடல்</string>
+    <string name="layout_overall_ratings">ஒட்டுமொத்த மதிப்பீடுகள்</string>
+    <string name="layout_overall_ratings_sub_on">நிலையான மற்றும் TMDB மதிப்பீடுகள் காட்டப்படும்.</string>
+    <string name="layout_overall_ratings_sub_off">நிலையான மற்றும் TMDB மதிப்பீடுகள் மறைக்கப்பட்டுள்ளன. விவரப் பக்கங்களில் MDBList வழங்குநர் அமைப்புகளுக்கு முன்னுரிமை உண்டு.</string>
 </resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -2685,4 +2685,7 @@
     <string name="cloud_library_error_disabled">Bulut kütüphanesi kapalı.</string>
     <string name="cloud_library_search_clear">Aramayı temizle</string>
     <string name="upcoming_section_title">Yaklaşanlar</string>
+    <string name="layout_overall_ratings">Genel Puanlar</string>
+    <string name="layout_overall_ratings_sub_on">Standart ve TMDB puanları gösterilir.</string>
+    <string name="layout_overall_ratings_sub_off">Standart ve TMDB puanları gizlenir. Ayrıntı sayfalarında MDBList sağlayıcısının ayarları önceliklidir.</string>
 </resources>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -1196,4 +1196,7 @@
     <string name="cloud_library_error_provider_unavailable">Thư viện đám mây không có sẵn cho %1$s.</string>
     <string name="cloud_library_error_disabled">Thư viện đám mây bị vô hiệu hóa.</string>
     <string name="cloud_library_search_clear">Xóa tìm kiếm</string>
+    <string name="layout_overall_ratings">Xếp hạng tổng thể</string>
+    <string name="layout_overall_ratings_sub_on">Xếp hạng tiêu chuẩn và TMDB được hiển thị.</string>
+    <string name="layout_overall_ratings_sub_off">Xếp hạng tiêu chuẩn và TMDB bị ẩn. Trên các trang chi tiết, cài đặt nhà cung cấp MDBList được ưu tiên.</string>
 </resources>

--- a/res/values-zh-cn/strings.xml
+++ b/res/values-zh-cn/strings.xml
@@ -2453,4 +2453,7 @@
     <string name="cloud_library_error_provider_unavailable">%1$s 的云媒体库不可用。</string>
     <string name="cloud_library_error_disabled">云媒体库已禁用。</string>
     <string name="cloud_library_search_clear">清除搜索</string>
+    <string name="layout_overall_ratings">总体评分</string>
+    <string name="layout_overall_ratings_sub_on">显示标准评分和 TMDB 评分。</string>
+    <string name="layout_overall_ratings_sub_off">标准评分和 TMDB 评分已隐藏。在详情页面上，MDBList 提供商设置优先。</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -2790,4 +2790,7 @@
     <string name="licenses_attributions_premiumize_body">Nuvio connects to Premiumize for account authentication, cloud library access, cache checks, and cloud playback features. Nuvio is not affiliated with or endorsed by Premiumize.</string>
     <string name="licenses_attributions_torbox_title">TorBox</string>
     <string name="licenses_attributions_torbox_body">Nuvio connects to TorBox for account authentication, cloud library access, cache checks, and cloud playback features. Nuvio is not affiliated with or endorsed by TorBox.</string>
+    <string name="layout_overall_ratings">Overall Ratings</string>
+    <string name="layout_overall_ratings_sub_on">Standard and TMDB ratings are shown.</string>
+    <string name="layout_overall_ratings_sub_off">Standard and TMDB ratings are hidden. MDBList provider settings take priority on detail pages.</string>
 </resources>


### PR DESCRIPTION
Adds a home setting to show or hide the overall ratings, matching the Overall Ratings toggle in the Android app.

When it is off, the standard IMDB and TMDB ratings are hidden on the home hero and on the detail page. MDBList provider ratings still follow their own settings and keep priority on detail pages, same as Android.

Default stays on, so nothing changes unless you turn it off. The visibility rules are ported from the Android ImdbRatingVisibility model and covered by a small unit test.
