### PR TITLE
Match seek scrub rates to the app

### DIFF
--- a/js/core/player/playerScrubRates.js
+++ b/js/core/player/playerScrubRates.js
@@ -1,0 +1,37 @@
+// Ported from Android NuvioTV ui/screens/player/PlayerScrubRates.kt so the web
+// player scrubs at the same rate as the app.
+//
+// Remotes fire repeated key events while a direction key is held (the repeat
+// count grows). Mapping that count to progressively larger steps makes long
+// holds scrub faster without changing the feel of a single tap.
+
+export const STEP_SHORT_MS = 10000;
+export const STEP_MEDIUM_MS = 20000;
+export const STEP_LONG_MS = 30000;
+export const STEP_VERY_LONG_MS = 60000;
+
+const MEDIUM_REPEAT_THRESHOLD = 3;
+const LONG_REPEAT_THRESHOLD = 8;
+const VERY_LONG_REPEAT_THRESHOLD = 15;
+
+// Seek step magnitude (always positive) for the given key repeat count. Callers
+// apply the sign for forward / backward.
+export function stepMsForKeyRepeat(repeatCount) {
+  const count = Math.max(0, Math.trunc(Number(repeatCount)) || 0);
+  if (count >= VERY_LONG_REPEAT_THRESHOLD) {
+    return STEP_VERY_LONG_MS;
+  }
+  if (count >= LONG_REPEAT_THRESHOLD) {
+    return STEP_LONG_MS;
+  }
+  if (count >= MEDIUM_REPEAT_THRESHOLD) {
+    return STEP_MEDIUM_MS;
+  }
+  return STEP_SHORT_MS;
+}
+
+// Signed delta for a rewind (negative) or forward (positive) scrub.
+export function deltaMsForKeyRepeat(repeatCount, forward) {
+  const step = stepMsForKeyRepeat(repeatCount);
+  return forward ? step : -step;
+}

--- a/js/core/player/playerScrubRates.test.mjs
+++ b/js/core/player/playerScrubRates.test.mjs
@@ -1,0 +1,31 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  STEP_SHORT_MS,
+  STEP_MEDIUM_MS,
+  STEP_LONG_MS,
+  STEP_VERY_LONG_MS,
+  stepMsForKeyRepeat,
+  deltaMsForKeyRepeat
+} from "./playerScrubRates.js";
+
+test("step ramps with hold", () => {
+  assert.equal(stepMsForKeyRepeat(0), STEP_SHORT_MS);
+  assert.equal(stepMsForKeyRepeat(2), STEP_SHORT_MS);
+  assert.equal(stepMsForKeyRepeat(3), STEP_MEDIUM_MS);
+  assert.equal(stepMsForKeyRepeat(7), STEP_MEDIUM_MS);
+  assert.equal(stepMsForKeyRepeat(8), STEP_LONG_MS);
+  assert.equal(stepMsForKeyRepeat(14), STEP_LONG_MS);
+  assert.equal(stepMsForKeyRepeat(15), STEP_VERY_LONG_MS);
+  assert.equal(stepMsForKeyRepeat(100), STEP_VERY_LONG_MS);
+});
+
+test("delta applies direction", () => {
+  assert.equal(deltaMsForKeyRepeat(0, false), -STEP_SHORT_MS);
+  assert.equal(deltaMsForKeyRepeat(8, true), STEP_LONG_MS);
+});
+
+test("step clamps a negative repeat count", () => {
+  assert.equal(stepMsForKeyRepeat(-1), STEP_SHORT_MS);
+});

--- a/js/core/player/playerScrubRates.test.mjs
+++ b/js/core/player/playerScrubRates.test.mjs
@@ -26,6 +26,20 @@ test("delta applies direction", () => {
   assert.equal(deltaMsForKeyRepeat(8, true), STEP_LONG_MS);
 });
 
+test("media seek directions share the Android ramp", () => {
+  const repeatCounts = [0, 3, 8, 15];
+  const expected = [STEP_SHORT_MS, STEP_MEDIUM_MS, STEP_LONG_MS, STEP_VERY_LONG_MS];
+
+  assert.deepEqual(
+    repeatCounts.map((count) => deltaMsForKeyRepeat(count, true)),
+    expected
+  );
+  assert.deepEqual(
+    repeatCounts.map((count) => deltaMsForKeyRepeat(count, false)),
+    expected.map((step) => -step)
+  );
+});
+
 test("step clamps a negative repeat count", () => {
   assert.equal(stepMsForKeyRepeat(-1), STEP_SHORT_MS);
 });

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -13,7 +13,7 @@ import {
   shouldAllowNativePlaybackDuringStartupAudioGate
 } from "../../../core/player/startupAudioGatePolicy.js";
 import { isTerminalHlsHttpStatus } from "../../../core/player/hlsNetworkErrorPolicy.js";
-import { stepMsForKeyRepeat } from "../../../core/player/playerScrubRates.js";
+import { deltaMsForKeyRepeat } from "../../../core/player/playerScrubRates.js";
 import { buildClockFormatOptions, resolveSystemHour12 } from "../../../core/player/clockFormat.js";
 import { resolveSubtitleStyleControlAvailability } from "../../../core/player/subtitlePresentationCapabilities.js";
 import {
@@ -10218,10 +10218,10 @@ export const PlayerScreen = {
     this.seekPreviewDirection = direction;
     this.seekRepeatCount += 1;
 
-    const stepSeconds = stepMsForKeyRepeat(this.seekRepeatCount - 1) / 1000;
+    const deltaSeconds = deltaMsForKeyRepeat(this.seekRepeatCount - 1, direction > 0) / 1000;
     const duration = this.getPlaybackDurationSeconds();
     const base = this.seekPreviewSeconds == null ? currentTime : Number(this.seekPreviewSeconds);
-    let next = base + direction * stepSeconds;
+    let next = base + deltaSeconds;
     if (duration > 0) {
       next = clamp(next, 0, duration);
     } else {
@@ -10397,7 +10397,7 @@ export const PlayerScreen = {
     return codeMap[keyCode] || null;
   },
 
-  applyMediaAction(action) {
+  applyMediaAction(action, event = null) {
     if (this.isExternalFrameMode() || !action) {
       return;
     }
@@ -10422,12 +10422,12 @@ export const PlayerScreen = {
     }
 
     if (action === "fastForward") {
-      this.quickSeekBy(30);
+      this.beginSeekPreview(1, Boolean(event?.repeat));
       return;
     }
 
     if (action === "rewind") {
-      this.quickSeekBy(-30);
+      this.beginSeekPreview(-1, Boolean(event?.repeat));
     }
   },
 
@@ -18902,7 +18902,7 @@ export const PlayerScreen = {
       event?.preventDefault?.();
       event?.stopPropagation?.();
       event?.stopImmediatePropagation?.();
-      this.applyMediaAction(mediaAction);
+      this.applyMediaAction(mediaAction, event);
       return;
     }
 

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -13,6 +13,7 @@ import {
   shouldAllowNativePlaybackDuringStartupAudioGate
 } from "../../../core/player/startupAudioGatePolicy.js";
 import { isTerminalHlsHttpStatus } from "../../../core/player/hlsNetworkErrorPolicy.js";
+import { stepMsForKeyRepeat } from "../../../core/player/playerScrubRates.js";
 import { buildClockFormatOptions, resolveSystemHour12 } from "../../../core/player/clockFormat.js";
 import { resolveSubtitleStyleControlAvailability } from "../../../core/player/subtitlePresentationCapabilities.js";
 import {
@@ -10217,16 +10218,7 @@ export const PlayerScreen = {
     this.seekPreviewDirection = direction;
     this.seekRepeatCount += 1;
 
-    const stepSeconds =
-      this.seekRepeatCount >= 18
-        ? 120
-        : this.seekRepeatCount >= 12
-          ? 60
-          : this.seekRepeatCount >= 7
-            ? 30
-            : this.seekRepeatCount >= 3
-              ? 20
-              : 10;
+    const stepSeconds = stepMsForKeyRepeat(this.seekRepeatCount - 1) / 1000;
     const duration = this.getPlaybackDurationSeconds();
     const base = this.seekPreviewSeconds == null ? currentTime : Number(this.seekPreviewSeconds);
     let next = base + direction * stepSeconds;

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -4123,7 +4123,7 @@ export const PlayerScreen = {
         : null;
     return Boolean(
       isLikelyHlsMimeType.call(PlayerController, declaredSourceType) ||
-        isLikelyHlsMimeType.call(PlayerController, inferredSourceType)
+      isLikelyHlsMimeType.call(PlayerController, inferredSourceType)
     );
   },
 


### PR DESCRIPTION
The Web player now uses the Android TV PlayerScrubRates contract for both held D-pad seeking and Media Fast Forward/Rewind keys.

Scrub steps are 10s, 20s, 30s, and 60s as the key repeat count increases, capped at 60s. Repeated media-key events use the same accumulated seek preview path as D-pad events instead of a fixed 30s jump.

Added unit coverage for forward and rewind media seek deltas.