### PR TITLE
Fix broken Trakt list posters

### DIFF
--- a/js/core/trakt/traktImageUrl.js
+++ b/js/core/trakt/traktImageUrl.js
@@ -1,0 +1,28 @@
+// Ported from Android NuvioTV core/trakt/TraktImageUtils.kt so web renders the
+// same Trakt artwork as the app.
+//
+// The Trakt API returns image URLs without a scheme, e.g.
+// "media.trakt.tv/images/movies/poster.jpg.webp". A browser treats that as a
+// relative path and the poster fails to load, so we restore the https scheme
+// the app applies before using the URL.
+
+const TRAKT_HOST_PATTERN = /^[a-z0-9.-]*trakt\.tv\//i;
+
+// Returns the URL with an https scheme when it points at a Trakt host, leaving
+// already-absolute or unrelated URLs untouched.
+export function toTraktImageUrl(value) {
+  const normalized = String(value || "").trim();
+  if (/^https:\/\//i.test(normalized)) {
+    return normalized;
+  }
+  if (/^http:\/\//i.test(normalized)) {
+    return `https://${normalized.slice(normalized.indexOf("://") + 3)}`;
+  }
+  if (normalized.startsWith("//")) {
+    return `https:${normalized}`;
+  }
+  if (TRAKT_HOST_PATTERN.test(normalized)) {
+    return `https://${normalized}`;
+  }
+  return normalized;
+}

--- a/js/core/trakt/traktImageUrl.test.mjs
+++ b/js/core/trakt/traktImageUrl.test.mjs
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { toTraktImageUrl } from "./traktImageUrl.js";
+
+test("normalizes trakt image hosts to https", () => {
+  assert.equal(
+    toTraktImageUrl("media.trakt.tv/images/movies/poster.jpg.webp"),
+    "https://media.trakt.tv/images/movies/poster.jpg.webp"
+  );
+  assert.equal(
+    toTraktImageUrl("//media.trakt.tv/images/movies/poster.jpg.webp"),
+    "https://media.trakt.tv/images/movies/poster.jpg.webp"
+  );
+  assert.equal(
+    toTraktImageUrl("http://media.trakt.tv/images/movies/poster.jpg.webp"),
+    "https://media.trakt.tv/images/movies/poster.jpg.webp"
+  );
+});
+
+test("keeps an https url unchanged", () => {
+  assert.equal(
+    toTraktImageUrl("https://walter-r2.trakt.tv/images/movies/poster.jpg.webp"),
+    "https://walter-r2.trakt.tv/images/movies/poster.jpg.webp"
+  );
+});
+
+test("leaves non trakt urls alone", () => {
+  assert.equal(
+    toTraktImageUrl("image.tmdb.org/t/p/w342/poster.jpg"),
+    "image.tmdb.org/t/p/w342/poster.jpg"
+  );
+  assert.equal(toTraktImageUrl(""), "");
+});

--- a/js/data/repository/libraryRepository.js
+++ b/js/data/repository/libraryRepository.js
@@ -1,4 +1,5 @@
 import { AuthManager } from "../../core/auth/authManager.js";
+import { toTraktImageUrl } from "../../core/trakt/traktImageUrl.js";
 import { SavedLibrarySyncService } from "../../core/profile/savedLibrarySyncService.js";
 import { ProfileManager } from "../../core/profile/profileManager.js";
 import { LocalStore } from "../../core/storage/localStore.js";
@@ -526,14 +527,15 @@ function toPersonalList(raw = {}) {
 
 function bestTraktImage(images = {}, kind) {
   const candidates = images?.[kind];
+  let url = null;
   if (Array.isArray(candidates)) {
-    return candidates.find((entry) => typeof entry === "string") || null;
+    url = candidates.find((entry) => typeof entry === "string") || null;
+  } else if (typeof candidates === "string") {
+    url = candidates;
+  } else if (candidates && typeof candidates === "object") {
+    url = candidates.full || candidates.medium || candidates.thumb || null;
   }
-  if (typeof candidates === "string") return candidates;
-  if (candidates && typeof candidates === "object") {
-    return candidates.full || candidates.medium || candidates.thumb || null;
-  }
-  return null;
+  return url ? toTraktImageUrl(url) : null;
 }
 
 function toSavedItemFromTraktList(entry) {


### PR DESCRIPTION
Trakt returns image URLs without a scheme (like `media.trakt.tv/images/...`), so saved Trakt list posters and backgrounds loaded as relative paths and showed up blank in the library.

The app already normalizes these URLs. This ports that small helper (`toTraktImageUrl`) and uses it in `bestTraktImage` so the artwork loads. Absolute and non Trakt URLs pass through unchanged.

Added a unit test that mirrors the app's test for the same helper.