### PR TITLE
Stop renagging about a dismissed app update

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -21,6 +21,7 @@ import { Platform } from "./platform/index.js";
 import { LocalStore } from "./core/storage/localStore.js";
 import { I18n } from "./i18n/index.js";
 import { getLatestAppUpdate } from "./core/update/appUpdateService.js";
+import { shouldShowUpdate } from "./core/update/updateBannerPolicy.js";
 import { showAppUpdatePrompt } from "./ui/components/appUpdatePrompt.js";
 import { resolveExperienceRoute } from "./core/profile/experienceModeRouting.js";
 
@@ -48,6 +49,7 @@ let appShellRendered = false;
 let updateCheckStarted = false;
 
 const APP_VERSION = typeof __NUVIO_APP_VERSION__ !== "undefined" ? __NUVIO_APP_VERSION__ : "0.0.0";
+const UPDATE_DISMISSED_TAG_KEY = "app_update_dismissed_tag";
 
 function markBootStage(stage) {
   const guard = globalThis.NuvioBootGuard;
@@ -75,10 +77,16 @@ async function checkForAppUpdateOnStartup() {
     if (!update) {
       return;
     }
+    const dismissedTag = LocalStore.get(UPDATE_DISMISSED_TAG_KEY, null);
+    if (!shouldShowUpdate({ isRemoteNewer: true, dismissedTag, updateTag: update.tag })) {
+      return;
+    }
     if (!(await waitForInitialRoute())) {
       return;
     }
-    showAppUpdatePrompt(update);
+    showAppUpdatePrompt(update, {
+      onClose: () => LocalStore.set(UPDATE_DISMISSED_TAG_KEY, update.tag)
+    });
   } catch (error) {
     console.warn("App update check failed", error);
   }

--- a/js/core/update/updateBannerPolicy.js
+++ b/js/core/update/updateBannerPolicy.js
@@ -1,0 +1,19 @@
+// Ported from Android NuvioTV updater/UpdateBannerPolicy.kt so the web update
+// prompt behaves like the app: an automatic check does not keep showing a
+// version the user already dismissed, while a manual check always shows it.
+
+export function shouldShowUpdate({
+  isRemoteNewer,
+  force = false,
+  bannerEnabled = true,
+  dismissedTag = null,
+  updateTag
+}) {
+  if (!isRemoteNewer) {
+    return false;
+  }
+  if (force) {
+    return true;
+  }
+  return bannerEnabled && dismissedTag !== updateTag;
+}

--- a/js/core/update/updateBannerPolicy.test.mjs
+++ b/js/core/update/updateBannerPolicy.test.mjs
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldShowUpdate } from "./updateBannerPolicy.js";
+
+test("automatic check shows a new update when the banner is enabled", () => {
+  assert.equal(
+    shouldShowUpdate({
+      isRemoteNewer: true,
+      force: false,
+      bannerEnabled: true,
+      dismissedTag: null,
+      updateTag: "v1.2.0"
+    }),
+    true
+  );
+});
+
+test("dismissed update stays hidden during automatic checks", () => {
+  assert.equal(
+    shouldShowUpdate({
+      isRemoteNewer: true,
+      force: false,
+      bannerEnabled: true,
+      dismissedTag: "v1.2.0",
+      updateTag: "v1.2.0"
+    }),
+    false
+  );
+});
+
+test("a newer tag is shown after the previous update was dismissed", () => {
+  assert.equal(
+    shouldShowUpdate({
+      isRemoteNewer: true,
+      force: false,
+      bannerEnabled: true,
+      dismissedTag: "v1.2.0",
+      updateTag: "v1.3.0"
+    }),
+    true
+  );
+});
+
+test("manual check shows the update despite dismissal and a disabled banner", () => {
+  assert.equal(
+    shouldShowUpdate({
+      isRemoteNewer: true,
+      force: true,
+      bannerEnabled: false,
+      dismissedTag: "v1.2.0",
+      updateTag: "v1.2.0"
+    }),
+    true
+  );
+});
+
+test("current version never shows as an update", () => {
+  assert.equal(
+    shouldShowUpdate({
+      isRemoteNewer: false,
+      force: true,
+      bannerEnabled: true,
+      dismissedTag: null,
+      updateTag: "v1.2.0"
+    }),
+    false
+  );
+});

--- a/js/ui/components/appUpdatePrompt.js
+++ b/js/ui/components/appUpdatePrompt.js
@@ -59,7 +59,7 @@ export function buildReleaseNotesContent(notes, documentRef = globalThis.documen
   return container;
 }
 
-export function showAppUpdatePrompt(update, { documentRef = globalThis.document } = {}) {
+export function showAppUpdatePrompt(update, { documentRef = globalThis.document, onClose } = {}) {
   if (!update || !documentRef?.body) {
     return null;
   }
@@ -81,9 +81,20 @@ export function showAppUpdatePrompt(update, { documentRef = globalThis.document 
   content.appendChild(notes);
 
   let dialog = null;
+  let closed = false;
+  const notifyClosed = () => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    if (typeof onClose === "function") {
+      onClose();
+    }
+  };
   const close = () => {
     const activeDialog = dialog;
     dialog = null;
+    notifyClosed();
     activeDialog?.destroy();
   };
 
@@ -111,6 +122,7 @@ export function showAppUpdatePrompt(update, { documentRef = globalThis.document 
     ],
     onDismiss: () => {
       dialog = null;
+      notifyClosed();
     }
   });
   dialog.mount(documentRef.body);


### PR DESCRIPTION
## Summary

Remember the release tag dismissed from the automatic startup update prompt so the same update is not shown on every launch. A newer release tag is shown again, and the manual Settings check remains able to show the current update.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix
- [x] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [ ] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

The startup release check showed the same newer release again after the user closed its prompt. The Web app should remember the dismissed release tag, matching the Android TV updater behavior, while preserving an explicit manual check.

## Issue or approval

Approved by the repository maintainer in this review request for PR #701 after semantic review and merge-tree validation.

## Reproduction steps

1. Run a build whose current version is older than the latest GitHub release.
2. Launch the app and close the automatic update prompt.
3. Restart the app while the same release is still current.
4. Before this change, the prompt appeared again; after this change, it remains hidden.
5. Publish or expose a newer release tag and restart; the newer prompt is shown.
6. Use Settings > Check for updates; the current update is still shown manually.

## Old behavior

Every startup check displayed the same newer release after the prompt had been closed.

## New behavior

Automatic checks store the dismissed release tag and suppress only that same tag. A different newer tag is shown automatically, and the manual Settings check continues to show the available update regardless of dismissal.

## Platform impact

- Samsung Tizen: Shared Web bootstrap behavior; no platform-specific API change. The Tizen package was built successfully from the merge tree; no physical TV test was available.
- LG webOS: Shared Web bootstrap behavior; no platform-specific API change. The webOS package was built successfully from the merge tree; no physical TV test was available.
- Browser development mode: Shared startup behavior; no physical browser UI flow was run.
- Installer / packaging: No packaging logic or metadata change.
- Wrapper repositories: No wrapper change.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen .wgt packaging changed
- [ ] webOS .ipk packaging changed
- [ ] App identifiers or metadata changed
- [ ] local.properties / environment handling changed
- [ ] sync:tizen changed
- [ ] sync:webos changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a documented glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a documented bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a documented bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included reproduction steps and testing notes for this approved behavior change.
- [x] I listed the testing performed below.

## Scope boundaries

Only the automatic update prompt dismissal state and its unit-test coverage changed. The release service, manual Settings check, prompt layout, playback, navigation, packaging logic, app identifiers, wrappers, and dependencies were intentionally left unchanged.

## Testing

### Devices / platforms tested

No physical TV, simulator, or browser UI confirmation was available. Validation used the official GitHub PR merge tree for commit 36599370d61d3977e95ff34534cea2988eca3e62.

### Commands tested

```sh
git diff --check a214b9483758374d1ba0f01b9cc80e14a72f366c..HEAD
node --check js/app.js
node --check js/core/update/updateBannerPolicy.js
node --check js/ui/components/appUpdatePrompt.js
npm test
npm run build
npm run package:tizen
npm run package:webos
```

All 20 project tests passed. The build, Tizen WGT, and webOS IPK completed successfully. The generated bundle and both packaged bundles contain the dismissal key. Targeted ESLint passed; Prettier reports only two pre-existing base-file lines in js/app.js.

### Manual test flow

The automatic/manual decision matrix was checked against the Android TV UpdateBannerPolicy implementation: a dismissed tag is hidden only for automatic checks, a newer tag is shown, and a manual check remains forced.

## Screenshots / Video

Not a UI change; the existing prompt layout and focus structure are unchanged.

## Logs

Not applicable; this change does not alter playback, installation, or crash handling.

## Regression risk

Low. The new startup import and local-storage read are guarded by the existing startup error path, and storage writes use LocalStore's existing error handling. Manual checks bypass the startup dismissal policy as before. Physical Tizen/webOS behavior was not confirmed on hardware.

## Breaking changes

None.

## Linked issues

No external issue was linked; maintainer approval is recorded in Issue or approval above for PR #701.