### PR TITLE
Stop counting short placeholder clips as a finished episode

### DIFF
--- a/js/core/player/naturalPlaybackCompletion.js
+++ b/js/core/player/naturalPlaybackCompletion.js
@@ -1,0 +1,30 @@
+// Ported from Android NuvioTV ui/screens/player/PlayerRuntimeControllerPlaybackEvents.kt
+// (shouldTreatAsNaturalPlaybackCompletion / isShortPlaceholderDuration) so the web
+// player matches the app when a stream reaches its end.
+//
+// Debrid cache-sync placeholders and unplayable source responses (RAR-only torrents,
+// "service unavailable" error clips) report a duration of a few seconds and then reach
+// the ended event. Counting those as a real finish marks the episode watched and chains
+// auto play next through a whole season, so they are excluded here.
+
+// Streams shorter than about 2:01 are treated as error or placeholder clips.
+export function isShortPlaceholderDuration(durationMs) {
+  return Number.isFinite(durationMs) && durationMs >= 1 && durationMs <= 120999;
+}
+
+export function shouldTreatAsNaturalPlaybackCompletion({
+  hasRenderedFirstFrame = true,
+  hasFatalError = false,
+  durationMs
+} = {}) {
+  if (hasFatalError) {
+    return false;
+  }
+  if (!hasRenderedFirstFrame) {
+    return false;
+  }
+  if (isShortPlaceholderDuration(durationMs)) {
+    return false;
+  }
+  return true;
+}

--- a/js/core/player/naturalPlaybackCompletion.test.mjs
+++ b/js/core/player/naturalPlaybackCompletion.test.mjs
@@ -1,0 +1,84 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isShortPlaceholderDuration,
+  shouldTreatAsNaturalPlaybackCompletion
+} from "./naturalPlaybackCompletion.js";
+
+test("a real episode end is a natural completion", () => {
+  assert.equal(
+    shouldTreatAsNaturalPlaybackCompletion({
+      hasRenderedFirstFrame: true,
+      hasFatalError: false,
+      durationMs: 2_400_000
+    }),
+    true
+  );
+});
+
+test("short debrid placeholder clips are not a natural completion", () => {
+  for (const durationMs of [5_000, 30_000, 120_999]) {
+    assert.equal(
+      shouldTreatAsNaturalPlaybackCompletion({
+        hasRenderedFirstFrame: true,
+        hasFatalError: false,
+        durationMs
+      }),
+      false
+    );
+  }
+});
+
+test("just over the placeholder threshold is a natural completion", () => {
+  assert.equal(
+    shouldTreatAsNaturalPlaybackCompletion({
+      hasRenderedFirstFrame: true,
+      hasFatalError: false,
+      durationMs: 121_000
+    }),
+    true
+  );
+});
+
+test("no first frame is not a natural completion", () => {
+  assert.equal(
+    shouldTreatAsNaturalPlaybackCompletion({
+      hasRenderedFirstFrame: false,
+      hasFatalError: false,
+      durationMs: 2_400_000
+    }),
+    false
+  );
+});
+
+test("a fatal error is not a natural completion", () => {
+  assert.equal(
+    shouldTreatAsNaturalPlaybackCompletion({
+      hasRenderedFirstFrame: true,
+      hasFatalError: true,
+      durationMs: 2_400_000
+    }),
+    false
+  );
+});
+
+test("unknown duration is still allowed when the first frame rendered", () => {
+  assert.equal(
+    shouldTreatAsNaturalPlaybackCompletion({
+      hasRenderedFirstFrame: true,
+      hasFatalError: false,
+      durationMs: 0
+    }),
+    true
+  );
+});
+
+test("isShortPlaceholderDuration covers error and cache-sync clips", () => {
+  assert.equal(isShortPlaceholderDuration(1), true);
+  assert.equal(isShortPlaceholderDuration(5_000), true);
+  assert.equal(isShortPlaceholderDuration(120_999), true);
+  assert.equal(isShortPlaceholderDuration(0), false);
+  assert.equal(isShortPlaceholderDuration(121_000), false);
+  assert.equal(isShortPlaceholderDuration(2_400_000), false);
+});

--- a/js/core/player/playerController.js
+++ b/js/core/player/playerController.js
@@ -8,6 +8,7 @@ import { hlsJsEngine } from "./engines/hlsJsEngine.js";
 import { dashJsEngine } from "./engines/dashJsEngine.js";
 import { resolvePlatformAvplayEngine } from "./engines/platformAvplayEngine.js";
 import { isTerminalHlsHttpStatus } from "./hlsNetworkErrorPolicy.js";
+import { isShortPlaceholderDuration } from "./naturalPlaybackCompletion.js";
 import {
   applyWebOsAudioCodecOverrides,
   detectWebOsAudioCapabilities
@@ -4932,6 +4933,11 @@ export const PlayerController = {
 
     const safePosition = Number(positionMs || 0);
     const safeDuration = Number(durationMs || 0);
+    if (isShortPlaceholderDuration(safeDuration)) {
+      // Debrid cache-sync/error clips must not create watched state or progress
+      // records, whether this is the periodic flush or the native ended event.
+      return false;
+    }
     const hasFiniteDuration = Number.isFinite(safeDuration) && safeDuration > 0;
     const hasReachedMinimumSyncPosition =
       Number.isFinite(safePosition) && safePosition >= MIN_PROGRESS_SYNC_DURATION_MS;

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -6994,9 +6994,6 @@ export const PlayerScreen = {
     if (!this.hasPresentedPlaybackFrame) {
       return false;
     }
-    if (this.nextEpisodeCardTriggered) {
-      return true;
-    }
     const durationSeconds = Number(this.getPlaybackDurationSeconds() || 0);
     const currentSeconds = Number(this.getPlaybackCurrentSeconds() || 0);
     if (
@@ -7006,6 +7003,12 @@ export const PlayerScreen = {
       currentSeconds < 0
     ) {
       return false;
+    }
+    if (!this.isNaturalPlaybackCompletionEligible(durationSeconds)) {
+      return false;
+    }
+    if (this.nextEpisodeCardTriggered) {
+      return true;
     }
     const settings = PlayerSettingsStore.get();
     const shouldShow = shouldShowNextEpisodeCardRule({
@@ -7022,6 +7025,32 @@ export const PlayerScreen = {
     return shouldShow;
   },
 
+  hasFatalPlaybackError() {
+    const controllerErrorCode =
+      typeof PlayerController.getLastPlaybackErrorCode === "function"
+        ? Number(PlayerController.getLastPlaybackErrorCode() || 0)
+        : 0;
+    const nativeErrorCode = Number(PlayerController.video?.error?.code || 0);
+    return (
+      this.isStartupErrorVisible() ||
+      Boolean(String(this.sourcesError || "").trim()) ||
+      controllerErrorCode > 0 ||
+      nativeErrorCode > 0
+    );
+  },
+
+  isNaturalPlaybackCompletionEligible(durationSeconds = this.getPlaybackDurationSeconds()) {
+    const duration = Number(durationSeconds);
+    if (!Number.isFinite(duration) || duration <= 0) {
+      return false;
+    }
+    return shouldTreatAsNaturalPlaybackCompletion({
+      hasRenderedFirstFrame: Boolean(this.hasPresentedPlaybackFrame),
+      hasFatalError: this.hasFatalPlaybackError(),
+      durationMs: duration * 1000
+    });
+  },
+
   hasPlaybackReachedNaturalEnd() {
     const durationSeconds = Number(this.getPlaybackDurationSeconds() || 0);
     const currentSeconds = Number(this.getPlaybackCurrentSeconds() || 0);
@@ -7036,9 +7065,7 @@ export const PlayerScreen = {
     const remainingSeconds = durationSeconds - currentSeconds;
     const progress = currentSeconds / durationSeconds;
     const reachedEnd = remainingSeconds <= 1 || progress >= 0.999;
-    return (
-      reachedEnd && shouldTreatAsNaturalPlaybackCompletion({ durationMs: durationSeconds * 1000 })
-    );
+    return reachedEnd && this.isNaturalPlaybackCompletionEligible(durationSeconds);
   },
 
   shouldPrefetchNextEpisodeStreams() {
@@ -7050,6 +7077,9 @@ export const PlayerScreen = {
       !Number.isFinite(currentSeconds) ||
       currentSeconds < 0
     ) {
+      return false;
+    }
+    if (!this.isNaturalPlaybackCompletionEligible(durationSeconds)) {
       return false;
     }
     return currentSeconds / durationSeconds >= NEXT_EPISODE_PREFETCH_PERCENT;
@@ -7222,6 +7252,10 @@ export const PlayerScreen = {
       !Number.isFinite(currentSeconds) ||
       currentSeconds < 0
     ) {
+      return false;
+    }
+    if (!this.isNaturalPlaybackCompletionEligible(durationSeconds)) {
+      this.nextEpisodeAutoplayAttemptedKey = "";
       return false;
     }
 
@@ -19294,6 +19328,31 @@ export const PlayerScreen = {
   },
 
   async handlePlaybackEnded() {
+    const naturalCompletion = this.isNaturalPlaybackCompletionEligible();
+    if (!naturalCompletion) {
+      // Match Android: an error/placeholder end is not a completion, so it
+      // must not stop scrobbling, mark watched, navigate away, or auto-play.
+      TrackingScrobbleService.cancel();
+      this.nextEpisodeAutoplayAttemptedKey = "";
+      this.nextEpisodeCardTriggered = false;
+      this.resetStillWatchingPromptState({ render: false });
+      if (this.nextEpisodeLaunching) {
+        this.cancelNextEpisodeLaunch();
+      }
+      this.clearPlaybackStallGuard();
+      this.releaseStartupAudioGate({ resume: false });
+      this.loadingVisible = false;
+      this.paused = true;
+      this.dismissPauseOverlay();
+      this.updateLoadingVisibility();
+      this.updateMediaSessionPlaybackState();
+      this.setControlsVisible(true, { focus: false });
+      this.renderControlButtons();
+      this.renderNextEpisodeCard();
+      this.updateUiTick();
+      return;
+    }
+
     // Immediate scrobble stop (may trigger mark-as-watched)
     if (TrackingScrobbleService.isEnabled()) {
       TrackingScrobbleService.stop(this.buildScrobbleContext());

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -15,6 +15,7 @@ import {
 import { isTerminalHlsHttpStatus } from "../../../core/player/hlsNetworkErrorPolicy.js";
 import { buildClockFormatOptions, resolveSystemHour12 } from "../../../core/player/clockFormat.js";
 import { resolveSubtitleStyleControlAvailability } from "../../../core/player/subtitlePresentationCapabilities.js";
+import { shouldTreatAsNaturalPlaybackCompletion } from "../../../core/player/naturalPlaybackCompletion.js";
 import {
   ensureWebOsImageProxyReady,
   normalizeImageUrl,
@@ -7034,7 +7035,10 @@ export const PlayerScreen = {
     }
     const remainingSeconds = durationSeconds - currentSeconds;
     const progress = currentSeconds / durationSeconds;
-    return remainingSeconds <= 1 || progress >= 0.999;
+    const reachedEnd = remainingSeconds <= 1 || progress >= 0.999;
+    return (
+      reachedEnd && shouldTreatAsNaturalPlaybackCompletion({ durationMs: durationSeconds * 1000 })
+    );
   },
 
   shouldPrefetchNextEpisodeStreams() {


### PR DESCRIPTION
## Summary

Porta su Web la correzione Android per cui clip Debrid placeholder/error di pochi secondi non devono essere considerate completamenti naturali. La correzione blocca anche i percorsi Web equivalenti che potevano creare progresso, stato watched, card/prefetch o auto-play della puntata successiva.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [ ] LG webOS
- [x] Browser development mode
- [x] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [x] Resume / Watch progress
- [x] Continue Watching
- [x] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Debrid cache-sync placeholder e risposte source non riproducibili, come torrent RAR-only o errori di servizio, possono esporre una durata di pochi secondi e generare `ended`. Prima della correzione questo poteva marcare l’episodio come visto e concatenare l’auto-play fino a più episodi senza riproduzione reale. Il comportamento atteso è quello già corretto su Android TV.

## Issue or approval

Related bug #2819: [NuvioMedia/NuvioTV#2819](https://github.com/NuvioMedia/NuvioTV/issues/2819), già risolto sul client Android e usato come contratto di parità.

## Reproduction steps

1. Abilitare Auto-play Next Episode.
2. Aprire una serie e avviare un episodio.
3. Selezionare una sorgente Debrid che restituisce un placeholder/error clip breve, per esempio RAR-only o “service unavailable”.
4. Lasciare arrivare la clip a `ended`.
5. Verificare che l’episodio non venga marcato visto e che non partano card, prefetch o auto-play della puntata successiva.

## Old behavior

Una clip breve poteva essere considerata completata. Il flush del player e lo scrobble potevano salvare il completamento, mentre il controllo della schermata poteva mostrare/precaricare/avviare la puntata successiva o navigare fuori dal player.

## New behavior

Le durate placeholder fino a 120.999 ms non sono completamenti naturali. Il player non salva progresso/watched per questi stream, non interrompe lo scrobble come completamento, non arma card/prefetch/auto-play e resta nel player in caso di `ended` non naturale. Le azioni manuali dell’utente per scegliere o avviare una puntata successiva non vengono rimosse.

## Platform impact

- Samsung Tizen: il percorso condiviso mantiene la protezione per placeholder/error clip; nessuna API AVPlay o packaging modificata.
- LG webOS: il percorso condiviso mantiene la protezione per placeholder/error clip; nessuna API webOS/Luna o packaging modificata.
- Browser development mode: stesso comportamento e stessa soglia del codice condiviso.
- Installer / packaging: nessun impatto.
- Wrapper repositories: nessun impatto.

## UI / behavior / playback impact

- [ ] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Non vengono modificati UI/layout/focus, selezione manuale delle sorgenti, policy dei provider, API native Tizen/webOS, packaging, installer, wrapper o la soglia generale dell’auto-play per episodi reali. La soglia di 120.999 ms resta quella già adottata da Android TV.

## Testing

### Devices / platforms tested

Nessun dispositivo fisico o simulatore TV è stato disponibile per questa verifica. La validazione è source-level e di build sul percorso condiviso Web; la conferma su Samsung/LG resta da eseguire sul dispositivo.

### Commands tested

```sh
npm test
npm run build
node --check js/core/player/playerController.js
node --check js/ui/screens/player/playerScreen.js
node --check js/core/player/naturalPlaybackCompletion.js
```

Risultato: 7 test passati sul merge tree ufficiale, 22 test passati sul branch della PR prima dell’aggiornamento della base, sintassi passata e build completato. Il controllo Prettier mirato segnala una riga preesistente non toccata in `playerScreen.js`; non è stata applicata formattazione globale.

### Manual test flow

Non eseguito su TV fisica. Il percorso verificato staticamente è: durata breve/error clip -> evento `ended` o flush periodico -> nessun watched/progresso di completamento, nessuna card/prefetch/auto-play automatico e permanenza nel player.

## Screenshots / Video

Not a UI change.

## Logs

Non sono disponibili log di un dispositivo fisico; la verifica non ha introdotto errori di sintassi o build. Il bug riprodotto dal codice è il percorso di completamento/progresso condiviso descritto sopra.

## Regression risk

La modifica tocca solo stream con durata positiva fino a 120.999 ms, errori di playback o assenza del primo frame. Episodi reali oltre soglia, comportamento manuale, sorgenti, sottotitoli, audio, packaging e API native restano invariati. Rischio residuo: la conferma del comportamento nativo `ended` su specifici firmware Tizen/webOS richiede test fisico.

## Breaking changes

None.

## Linked issues

Related to #2819: [NuvioMedia/NuvioTV#2819](https://github.com/NuvioMedia/NuvioTV/issues/2819).

