### PR TITLE
fix(player): keep waiting for AVPlay audio tracks before startup fallback

### DIFF
--- a/js/core/player/startupAudioGatePolicy.js
+++ b/js/core/player/startupAudioGatePolicy.js
@@ -26,3 +26,15 @@ export function selectStartupAudioFallbackOption(options = []) {
   );
   return supportedOptions.find((entry) => entry?.selected) || supportedOptions[0] || null;
 }
+
+// Startup exposes a synthetic audio entry as soon as a playback URL exists so
+// the controls have something to render. Tizen AVPlay (and webOS) only publish
+// the real track list a moment later, so that placeholder must never be treated
+// as the final answer for the preferred audio language.
+export function hasOnlyImplicitStartupAudioOptions(options = []) {
+  const list = Array.isArray(options) ? options : [];
+  if (!list.length) {
+    return true;
+  }
+  return list.every((option) => Boolean(option?.entry?.implicitAudioTrack));
+}

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -9,6 +9,7 @@ import {
 } from "../../../core/player/audioTrackCodecMetadata.js";
 import {
   canReleasePlayingNativeStartupAudioGate,
+  hasOnlyImplicitStartupAudioOptions,
   selectStartupAudioFallbackOption,
   shouldAllowNativePlaybackDuringStartupAudioGate
 } from "../../../core/player/startupAudioGatePolicy.js";
@@ -14654,7 +14655,13 @@ export const PlayerScreen = {
     }
 
     const preferredTargets = this.getStartupPreferredAudioLanguageTargets();
-    const isStillLoading = this.isAudioPreferenceDiscoveryPending();
+    // `loadedmetadata` fires before Tizen AVPlay publishes `getTotalTrackInfo`,
+    // so the option list can still hold nothing but the synthetic startup entry.
+    // Concluding there means falling back to the runtime's first audio track and
+    // latching that choice, which is why the preferred language never applied.
+    const isStillLoading =
+      this.isAudioPreferenceDiscoveryPending() ||
+      hasOnlyImplicitStartupAudioOptions(this.collectAudioOptionItems());
     const matchedRememberedOption = this.findRememberedAudioOption();
     const rememberedOption =
       isStillLoading && matchedRememberedOption?.entry?.implicitAudioTrack

--- a/tests/core/player/startupAudioGatePolicy.test.mjs
+++ b/tests/core/player/startupAudioGatePolicy.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  hasOnlyImplicitStartupAudioOptions,
+  selectStartupAudioFallbackOption
+} from "../../../js/core/player/startupAudioGatePolicy.js";
+
+const implicitOption = {
+  id: "audio-implicit-0",
+  supported: true,
+  selected: true,
+  languageKey: "",
+  entry: { implicitAudioTrack: true }
+};
+const realOption = (languageKey) => ({
+  id: `audio-avplay-${languageKey}`,
+  supported: true,
+  selected: false,
+  languageKey,
+  entry: {}
+});
+
+test("treats a missing audio option list as placeholder-only", () => {
+  assert.equal(hasOnlyImplicitStartupAudioOptions([]), true);
+  assert.equal(hasOnlyImplicitStartupAudioOptions(), true);
+  assert.equal(hasOnlyImplicitStartupAudioOptions(null), true);
+});
+
+test("treats the synthetic startup entry as placeholder-only", () => {
+  // Tizen AVPlay exposes no track list until after loadedmetadata, so the
+  // implicit entry must not settle the preferred-language decision.
+  assert.equal(hasOnlyImplicitStartupAudioOptions([implicitOption]), true);
+});
+
+test("stops waiting once a real audio track is exposed", () => {
+  assert.equal(hasOnlyImplicitStartupAudioOptions([realOption("en")]), false);
+  assert.equal(hasOnlyImplicitStartupAudioOptions([implicitOption, realOption("fr")]), false);
+});
+
+test("startup fallback still prefers the already selected supported track", () => {
+  const options = [realOption("fr"), { ...realOption("en"), selected: true }];
+  assert.equal(selectStartupAudioFallbackOption(options).languageKey, "en");
+});


### PR DESCRIPTION
## Summary

Potential fix for #683. On Tizen the preferred audio language was decided against a placeholder track list and then latched, so AVPlay's default audio track kept playing instead of the configured language. This makes the startup preference wait for the real AVPlay track list via the retry path that already exists.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [ ] LG webOS
- [ ] Browser development mode
- [x] Playback
- [x] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

`getImplicitAudioEntry()` (`js/ui/screens/player/playerScreen.js:16232`) synthesises a single audio entry as soon as a playback URL exists, so the controls have something to render before real tracks are known.

On Tizen, `onLoadedMetadata` / the AVPlay branch of `onPlaying` set `startupTrackPreferenceReady = true` and call `refreshTrackDialogs()` → `applyStartupAudioPreference()` **before** AVPlay publishes `getTotalTrackInfo`. At that moment:

- `collectAudioOptionItems()` returns only the implicit placeholder, whose language is empty;
- `isAudioPreferenceDiscoveryPending()` is `false` — `trackDiscoveryInProgress` is still `false` (`startTrackDiscoveryWindow` is called *after* `refreshTrackDialogs()` in `onLoadedMetadata`), and its `!getAudioEntries().length` clause is defeated by that same placeholder;
- so no preferred option is found, no retry is scheduled, and `applyStartupAudioFallback()` runs and sets `startupAudioPreferenceApplied = true`.

That flag is never cleared again on Tizen: the track-set-signature re-open in `refreshTrackDialogs` (`playerScreen.js:11655`) and the discovery-window extension in `startTrackDiscoveryWindow` (`playerScreen.js:11861`) are both gated on `Environment.isWebOS()`. When AVPlay later exposes the real list, nothing re-evaluates the preference, so its default first audio track keeps playing.

This matches the report: audio lands on an arbitrary non-preferred track, it is intermittent (it depends on whether AVPlay happens to have the list ready yet), and subtitles are unaffected because they resolve through a separate code path.

## Issue or approval

Fixes #683 (previously reported as #616).

## Reproduction steps

From #683 (Samsung Q68BA, Tizen, installed via Nuvio WebTV Installer, 0.3.35):

1. Open Nuvio Web.
2. Settings → Playback → set preferred audio language to English (secondary: none).
3. Play an episode with multiple audio tracks, one of which is English.
4. Observe the audio track that starts playing.

Reported frequency: often, more than 50% of starts.

## Old behavior

The preferred audio language decision was made against a one-entry placeholder list, concluded that the preferred language was unavailable, applied the runtime fallback and latched it. Playback started on AVPlay's default audio track — an arbitrary language — even though a matching track existed in the file. Opening the audio menu afterwards showed all the real tracks, including English, so the track list itself was fine; only the automatic selection was wrong. Subtitles were unaffected.

## New behavior

While the audio option list contains nothing but the implicit placeholder, the startup preference is treated as still loading. That routes into the existing bounded retry (`scheduleStartupAudioPreferenceRetry`, `playerScreen.js:14333`): 250 ms ticks for at most 6 s, each one calling `PlayerController.syncAvPlayTrackInfo({ force: true })` and re-running the preference. As soon as the real AVPlay list appears, the English track is matched and selected. If the window expires without real tracks, the previous fallback applies exactly as before.

| | Before | After |
|---|---|---|
| Options visible at decision time | 1 implicit placeholder | waits for the real list, up to 6 s |
| Retries scheduled on Tizen | 0 | up to 24 (250 ms × 6 s), existing mechanism |
| Result with an English track present | AVPlay default track, latched | English track |
| Result with no matching track | fallback to first supported track | unchanged |
| Platforms with no retry path (browser) | immediate fallback | immediate fallback (unchanged) |

## Platform impact

- Samsung Tizen: the platform this fixes. Shared code, Tizen-specific timing.
- LG webOS: touched (shared code path) but behaviour is unchanged in practice — webOS already reached the same state through `pendingWebOsAudioSelection` and its webOS-only re-open, and `hasOnlyImplicitStartupAudioOptions` only ever adds a wait that the webOS retry path already allowed.
- Browser development mode: `scheduleStartupAudioPreferenceRetry` returns `false` off-TV and `isAudioPreferenceDiscoveryPending()` stays `false`, so the fallback still applies immediately on the first pass. No added delay, no hang.
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Deliberately left out:

- The webOS-only guards in `refreshTrackDialogs` (`playerScreen.js:11655`) and `startTrackDiscoveryWindow` (`playerScreen.js:11861`) were **not** extended to Tizen. Extending them would allow a track re-selection after the 6 s window has closed, i.e. mid-playback, which is a larger and riskier change. If AVPlay takes longer than 6 s to publish its track list, this PR does not help and that follow-up would be the next step.
- `hasAudioTracksAvailable()` still counts the implicit placeholder, so the Tizen discovery window can still close early on `doneByData`. Left alone on purpose: the retry loop force-syncs AVPlay track info independently, and changing that predicate affects subtitle discovery too.
- No changes to the subtitle preference path, the remembered-track path, language matching/aliases, or the audio menu UI.
- No formatting or lint sweeps. `npm run format:check` currently reports 43 pre-existing unformatted files on `main` (`js/app.js`, `js/i18n/index.js`, and others); none are touched here and none were reformatted, so the pre-commit hook was bypassed to avoid bundling an unrelated 43-file reformat. The three files in this PR are Prettier-clean.

## Testing

### Devices / platforms tested

**No Smart TV hardware testing — I do not have a Samsung Tizen device to verify on. This is submitted as a candidate fix based on code-path analysis, and it needs confirmation on a real Tizen TV before it should be trusted.** Verification so far is static analysis plus the automated suite on macOS (Node 24).

### Commands tested

```sh
npm test          # 55/55 pass (51 pre-existing + 4 new)
npx eslint js/ui/screens/player/playerScreen.js js/core/player/startupAudioGatePolicy.js tests/core/player/startupAudioGatePolicy.test.mjs   # clean
npx prettier --check <the three changed files>   # clean
```

## Manual test flow

Not performed on device. The reproduction flow that needs confirming on a Tizen TV: set preferred audio language to English, start an episode that has an English audio track alongside others, and check that playback starts in English across several launches (the bug reproduced more than 50% of the time).

## Screenshots / Video

Not a UI change.

## Logs

Not applicable — no crash, blank screen, or platform API error involved; the failure is a wrong automatic selection.

## Regression risk

What was actually checked, by reading each branch that consumes `isStillLoading` in `applyStartupAudioPreference` (`playerScreen.js:14651`):

- `!preferredTargets.length` (preference off / "system" unresolved) returns before any of this, so users with no preferred language are untouched.
- The `!preferredOption` branch calls `scheduleStartupAudioPreferenceRetry()`; off-TV it returns `false` and `isAudioPreferenceDiscoveryPending()` is `false`, so control falls through to `applyStartupAudioFallback()` on the same pass. No path can wait forever.
- The retry deadline is set once (`playerScreen.js:14339`) and bounds the wait at `STARTUP_AUDIO_PREFERENCE_RETRY_WINDOW_MS` = 6000 ms.
- The remembered-track branch (`this.rememberedAudioTrackPreference && isStillLoading`) has the same fall-through shape, so a manually remembered track still applies.
- The "already selected and matching" early accept now refuses to be satisfied by the implicit placeholder, which is the intended correction.

Residual risk, stated plainly: on Tizen, startup audio selection can now take up to 6 s longer in the worst case where no matching track ever appears. In that window the previous code had already committed to the fallback track. Whether that is perceptible on device is exactly what I could not verify without hardware.

## Breaking changes

None.

## Linked issues

Fixes #683. Earlier report of the same defect: #616.
