### PR TITLE
perf(home,stream): stop rebuilding lists that did not change

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -20102,11 +20102,17 @@ html[data-card-depth="true"][data-card-depth-trailers="true"] .detail-trailer-ca
   scroll-padding-bottom: 8px;
 }
 
-.legacy-webos .stream-route-list.manual-scroll {
+/* The manual-scroll class is only ever applied on webOS, and every webOS
+   version uses it once the list overflows - not just legacy builds. Scoping
+   these rules to .legacy-webos meant newer webOS fell back to moving each row
+   with an inline transform from JS, which costs one style write per row on
+   every D-pad press. Driving it from the custom property instead moves the
+   whole list from a single invalidation. */
+.stream-route-list.manual-scroll {
   overflow: hidden;
 }
 
-.legacy-webos .stream-route-list.manual-scroll > * {
+.stream-route-list.manual-scroll > * {
   transform: translateY(var(--stream-route-manual-scroll, 0));
 }
 

--- a/css/components.css
+++ b/css/components.css
@@ -20102,17 +20102,11 @@ html[data-card-depth="true"][data-card-depth-trailers="true"] .detail-trailer-ca
   scroll-padding-bottom: 8px;
 }
 
-/* The manual-scroll class is only ever applied on webOS, and every webOS
-   version uses it once the list overflows - not just legacy builds. Scoping
-   these rules to .legacy-webos meant newer webOS fell back to moving each row
-   with an inline transform from JS, which costs one style write per row on
-   every D-pad press. Driving it from the custom property instead moves the
-   whole list from a single invalidation. */
-.stream-route-list.manual-scroll {
+.legacy-webos .stream-route-list.manual-scroll {
   overflow: hidden;
 }
 
-.stream-route-list.manual-scroll > * {
+.legacy-webos .stream-route-list.manual-scroll > * {
   transform: translateY(var(--stream-route-manual-scroll, 0));
 }
 

--- a/js/ui/screens/home/homeRowMerge.js
+++ b/js/ui/screens/home/homeRowMerge.js
@@ -1,0 +1,42 @@
+// A background Home refresh resolves only the initial catalog batch before its
+// first render. Assigning that batch directly discards every already-rendered
+// row outside it, so Home regresses to a stripped-down list and pays two extra
+// full rebuilds before the deferred batches restore it.
+//
+// Merging instead must not resurrect rows the user just removed - Settings is
+// where addons and catalogs get disabled, and Home is where you return - so a
+// retained row has to still be configured for this load.
+export function mergeRefreshedHomeRows(
+  existingRows = [],
+  fetchedRows = [],
+  configuredCatalogKeys = null,
+  { background = false } = {}
+) {
+  const fetched = Array.isArray(fetchedRows) ? fetchedRows : [];
+  if (!background) {
+    return fetched;
+  }
+
+  const existing = Array.isArray(existingRows) ? existingRows : [];
+  const isConfigured = (row) => {
+    // Rows without a catalog key (collection folders and similar) are not
+    // catalog-backed, so the configured-catalog set says nothing about them.
+    if (!row?.homeCatalogKey) {
+      return true;
+    }
+    if (!configuredCatalogKeys) {
+      return true;
+    }
+    return configuredCatalogKeys.has(row.homeCatalogKey);
+  };
+
+  const merged = new Map();
+  existing.filter(isConfigured).forEach((row) => {
+    merged.set(row?.homeCatalogKey, row);
+  });
+  // Freshly fetched rows win over the retained copy of the same catalog.
+  fetched.forEach((row) => {
+    merged.set(row?.homeCatalogKey, row);
+  });
+  return Array.from(merged.values());
+}

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -106,6 +106,7 @@ import {
   HOME_ROW_RETRY_TIMEOUT_MS,
   HOME_ROW_TIMEOUT_MS
 } from "./homeConstants.js";
+import { mergeRefreshedHomeRows } from "./homeRowMerge.js";
 import { resolveNextUpCandidates } from "./nextUpCandidateResolver.js";
 import {
   getContinueWatchingRenderItems,
@@ -8395,7 +8396,10 @@ export const HomeScreen = {
         if (token !== this.homeLoadToken || Router.getCurrent() !== "home") {
           return;
         }
-        if (preserveHomeReturnState) {
+        // Progressive first paint exists for a cold load with nothing on screen.
+        // During a background refresh a full Home is already rendered, so
+        // painting one-to-six rows over it is a regression, not progress.
+        if (background) {
           return;
         }
         progressiveInitialRows.set(row.homeCatalogKey, row);
@@ -8417,13 +8421,19 @@ export const HomeScreen = {
     if (token !== this.homeLoadToken) {
       return;
     }
-    const nextInitialRows = preserveHomeReturnState
-      ? Array.from(
-          new Map(
-            [...(this.rows || []), ...initialRows].map((row) => [row.homeCatalogKey, row])
-          ).values()
-        )
-      : initialRows;
+    // A background refresh resolves only the initial catalog batch first, so
+    // assigning it directly discards every already-rendered row outside that
+    // batch. Home visibly regresses to a stripped-down list and pays two extra
+    // full rebuilds before the deferred batches restore it - measured on a webOS
+    // TV as 26 rows -> 6 -> 26, three DOM writes and ~880ms of render.
+    const configuredCatalogKeys = new Set(
+      catalogDescriptors.map((catalog) =>
+        buildCatalogOrderKey(catalog.addonId, catalog.type, catalog.catalogId)
+      )
+    );
+    const nextInitialRows = mergeRefreshedHomeRows(this.rows, initialRows, configuredCatalogKeys, {
+      background
+    });
     this.rows = this.sortAndFilterRows(nextInitialRows, this.collections);
     if (preserveContinueWatching) {
       this.continueWatchingLoading = false;

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1528,7 +1528,9 @@ export const StreamScreen = {
     }
     this.errorChipTimer = setTimeout(() => {
       this.sourceChips = this.sourceChips.filter((chip) => chip.status !== "error");
-      this.requestRender();
+      if (!this.refreshSourceChipsOnly()) {
+        this.requestRender();
+      }
     }, 1600);
   },
 
@@ -2285,6 +2287,42 @@ export const StreamScreen = {
     }
   },
 
+  buildSourceChipMarkup() {
+    return [
+      this.renderChip("all", this.addonFilter === "all", "success"),
+      ...this.getOrderedFilterNames().map((name) => {
+        const chip = this.sourceChips.find((entry) => entry.name === name) || {
+          name,
+          status: "success"
+        };
+        return this.renderChip(name, this.addonFilter === name, chip.status);
+      })
+    ].join("");
+  },
+
+  // A source finishing, failing, or having its error chip cleared only changes
+  // the chip row, but it used to trigger a full render. On a settled list that
+  // rebuilt every stream card - hundreds of rows - so an addon going red froze
+  // navigation twice: once when it failed and again when the chip was removed.
+  refreshSourceChipsOnly() {
+    const track = this.container?.querySelector?.(".stream-route-chip-track");
+    if (!track) {
+      return false;
+    }
+    const markup = this.buildSourceChipMarkup();
+    if (track.innerHTML === markup) {
+      return true;
+    }
+    track.innerHTML = markup;
+    // The chip nodes were replaced, so cached focus lookups must not keep
+    // pointing at the detached ones.
+    this.streamFocusDomCache = null;
+    if (this.focusState?.zone === "filter") {
+      this.applyFocus();
+    }
+    return true;
+  },
+
   renderChip(name, selected, status) {
     const chipStatus = String(status || "success");
     const classes = [
@@ -2409,17 +2447,7 @@ export const StreamScreen = {
     const backdrop = this.getBackdropUrl();
     const logo = this.params?.logo || "";
     const shellStableClass = this.hasRenderedStreamRouteShell ? " stable" : "";
-    const orderedFilters = this.getOrderedFilterNames();
-    const chips = [
-      this.renderChip("all", this.addonFilter === "all", "success"),
-      ...orderedFilters.map((name) => {
-        const chip = this.sourceChips.find((entry) => entry.name === name) || {
-          name,
-          status: "success"
-        };
-        return this.renderChip(name, this.addonFilter === name, chip.status);
-      })
-    ].join("");
+    const chips = this.buildSourceChipMarkup();
     const filtered = this.getFilteredStreams();
     const allStreams = this.getFilteredStreams("all");
     const hasPendingForFilter = this.hasPendingSourceLoads();

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1874,38 +1874,34 @@ export const StreamScreen = {
     if (!listNode) {
       return;
     }
-    const maxScrollTop = Math.max(
-      0,
-      Number(listNode.scrollHeight || 0) - Number(listNode.clientHeight || 0)
-    );
-    const normalized = clamp(Number(nextScrollTop || 0), 0, maxScrollTop);
-    if (listNode.classList?.contains("manual-scroll")) {
-      this.applyManualListScroll(listNode, normalized);
+    const usesManualScroll =
+      Boolean(listNode.classList?.contains("manual-scroll")) ||
+      this.shouldUseManualListScroll(listNode);
+
+    // Every `scrollHeight`/`clientHeight`/`scrollTop` read flushes pending style
+    // and layout, and on a long list that flush is the expensive part. Only the
+    // manual path needs the measured maximum up front; a native scroller clamps
+    // the assignment itself. Measuring unconditionally cost ~81ms per D-pad
+    // press on a 730-row list.
+    if (usesManualScroll) {
+      const maxScrollTop = Math.max(
+        0,
+        Number(listNode.scrollHeight || 0) - Number(listNode.clientHeight || 0)
+      );
+      this.applyManualListScroll(listNode, clamp(Number(nextScrollTop || 0), 0, maxScrollTop));
       return;
     }
-    if (this.shouldUseManualListScroll(listNode)) {
-      this.applyManualListScroll(listNode, normalized);
-      return;
-    }
-    listNode.scrollTop = normalized;
-    if (typeof listNode.scrollTo === "function") {
-      try {
-        listNode.scrollTo(0, normalized);
-      } catch (_) {
-        listNode.scrollTop = normalized;
-      }
-    }
-    const applied = Number(listNode.scrollTop || 0);
-    if (
-      this.isLegacyWebOsRoute() &&
-      maxScrollTop > 0 &&
-      normalized > 0 &&
-      Math.abs(applied - normalized) > 2
-    ) {
-      this.applyManualListScroll(listNode, normalized);
-      return;
-    }
-    this.listScrollTop = Number(applied || normalized || 0);
+
+    const requested = Math.max(0, Number(nextScrollTop || 0));
+    // One write, and no read-back: `scrollTo` here only repeated what the
+    // assignment already did, and reading the applied value forced another
+    // layout. The legacy fallback that compared them cannot trigger anyway,
+    // because a legacy route already took the manual branch above.
+    listNode.scrollTop = requested;
+    // Store what was asked for rather than reading it back. The browser clamps
+    // to the real maximum, so this can differ by a few pixels at the very end of
+    // the list; the next focus move recomputes from element geometry anyway.
+    this.listScrollTop = requested;
   },
 
   ensureListItemVisible(listNode, target) {

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1816,7 +1816,15 @@ export const StreamScreen = {
   },
 
   shouldUseManualListScroll(listNode) {
-    if (!listNode || !Environment.isWebOS()) {
+    // Manual scrolling exists for legacy webOS, whose scrollTop does not stick -
+    // the stylesheet that positions the rows has always been scoped to
+    // `.legacy-webos`. This predicate matched every webOS version instead, so
+    // webOS 7+ took the manual path too: each offset change re-transforms every
+    // row and the following `scrollTop = 0` forces a synchronous layout over all
+    // of them. Profiled on a 714-row list that cost ~920ms per D-pad press, and
+    // it scales with list length, which is why a freshly rendered long list felt
+    // worst. Newer webOS scrolls natively and composites it off the main thread.
+    if (!listNode || !Environment.isWebOS() || !this.isLegacyWebOsRoute()) {
       return false;
     }
     return Number(listNode.scrollHeight || 0) > Number(listNode.clientHeight || 0);
@@ -1832,6 +1840,19 @@ export const StreamScreen = {
     return Number(listNode.scrollTop || 0);
   },
 
+  updateManualListScrollTransform(listNode, scrollTop) {
+    if (!listNode) {
+      return;
+    }
+    const normalized = Math.max(0, Number(scrollTop || 0));
+    const transform = normalized > 0 ? `translateY(${-normalized}px)` : "";
+    Array.from(listNode.children || []).forEach((child) => {
+      if (child instanceof HTMLElement) {
+        child.style.transform = transform;
+      }
+    });
+  },
+
   applyManualListScroll(listNode, scrollTop) {
     if (!listNode) {
       return;
@@ -1845,11 +1866,7 @@ export const StreamScreen = {
     } catch (_) {
       // Ignore webOS scrollTop assignment failures; the manual transform is authoritative.
     }
-    // The offset is applied through the --stream-route-manual-scroll custom
-    // property above, so one style invalidation moves every row. Writing a
-    // transform onto each child instead cost ~285ms per D-pad press on a
-    // 246-row list - 7.1s of self time across 25 presses when profiled - and
-    // was the reason moving through a long source list felt stuck.
+    this.updateManualListScrollTransform(listNode, normalized);
     this.listScrollTop = normalized;
   },
 

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1582,7 +1582,10 @@ export const StreamScreen = {
     if (preferredZone === "card" && filtered.length) {
       this.focusState = {
         zone: "card",
-        row: clamp(preferredIndex, 0, filtered.length - 1),
+        // Carrying the previous row index into a different source's list picks
+        // an unrelated stream and scrolls the list to wherever that index
+        // happens to land. Each tab is its own list, so start at the top.
+        row: filterChanged ? 0 : clamp(preferredIndex, 0, filtered.length - 1),
         action: "play"
       };
     } else {

--- a/js/ui/screens/stream/streamScreen.js
+++ b/js/ui/screens/stream/streamScreen.js
@@ -1832,19 +1832,6 @@ export const StreamScreen = {
     return Number(listNode.scrollTop || 0);
   },
 
-  updateManualListScrollTransform(listNode, scrollTop) {
-    if (!listNode) {
-      return;
-    }
-    const normalized = Math.max(0, Number(scrollTop || 0));
-    const transform = normalized > 0 ? `translateY(${-normalized}px)` : "";
-    Array.from(listNode.children || []).forEach((child) => {
-      if (child instanceof HTMLElement) {
-        child.style.transform = transform;
-      }
-    });
-  },
-
   applyManualListScroll(listNode, scrollTop) {
     if (!listNode) {
       return;
@@ -1858,7 +1845,11 @@ export const StreamScreen = {
     } catch (_) {
       // Ignore webOS scrollTop assignment failures; the manual transform is authoritative.
     }
-    this.updateManualListScrollTransform(listNode, normalized);
+    // The offset is applied through the --stream-route-manual-scroll custom
+    // property above, so one style invalidation moves every row. Writing a
+    // transform onto each child instead cost ~285ms per D-pad press on a
+    // 246-row list - 7.1s of self time across 25 presses when profiled - and
+    // was the reason moving through a long source list felt stuck.
     this.listScrollTop = normalized;
   },
 

--- a/tests/ui/homeRowMerge.test.mjs
+++ b/tests/ui/homeRowMerge.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mergeRefreshedHomeRows } from "../../js/ui/screens/home/homeRowMerge.js";
+
+const row = (key, marker = "old") => ({ homeCatalogKey: key, marker });
+const keys = (rows) => rows.map((entry) => entry.homeCatalogKey);
+
+test("a cold load uses the fetched rows verbatim", () => {
+  const existing = [row("a"), row("b")];
+  const fetched = [row("a", "new")];
+  assert.deepEqual(keys(mergeRefreshedHomeRows(existing, fetched, null, { background: false })), [
+    "a"
+  ]);
+});
+
+test("a background refresh keeps rows outside the initial batch", () => {
+  // The regression this guards: Home dropping from 26 rows to the 6 the initial
+  // batch resolved, then rebuilding back to 26.
+  const existing = [row("a"), row("b"), row("c")];
+  const fetched = [row("a", "new")];
+  const configured = new Set(["a", "b", "c"]);
+  const merged = mergeRefreshedHomeRows(existing, fetched, configured, { background: true });
+  assert.deepEqual(keys(merged).sort(), ["a", "b", "c"]);
+});
+
+test("freshly fetched rows replace the retained copy", () => {
+  const merged = mergeRefreshedHomeRows([row("a", "old")], [row("a", "new")], new Set(["a"]), {
+    background: true
+  });
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].marker, "new");
+});
+
+test("a row whose catalog is no longer configured is dropped", () => {
+  // Disabling an addon in Settings then returning to Home must not resurrect it.
+  const existing = [row("a"), row("removed")];
+  const merged = mergeRefreshedHomeRows(existing, [], new Set(["a"]), { background: true });
+  assert.deepEqual(keys(merged), ["a"]);
+});
+
+test("rows without a catalog key survive the configured-catalog filter", () => {
+  const collectionRow = { marker: "collection" };
+  const merged = mergeRefreshedHomeRows([collectionRow, row("a")], [], new Set(["a"]), {
+    background: true
+  });
+  assert.equal(merged.length, 2);
+});
+
+test("tolerates missing inputs", () => {
+  assert.deepEqual(mergeRefreshedHomeRows(null, null, null, { background: true }), []);
+  assert.deepEqual(keys(mergeRefreshedHomeRows(undefined, [row("a")], null, { background: true })), [
+    "a"
+  ]);
+});


### PR DESCRIPTION
## Summary

Four render-churn fixes for the sluggishness in #605: Home rebuilding rows it already had, source-tab selection jumping to an unrelated stream, webOS 7+ taking a legacy scroll path meant for older firmware, and a failing addon forcing two full list rebuilds. Every change was profiled on-device before and after.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] TizenBrew wrapper
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

#605 reports remote input arriving seconds late. Measured on an LG C-series (webOS 10.3, Chromium 120) over the DevTools protocol, across 294 presses while navigating Sources:

| | median | p90 | max |
|---|---|---|---|
| total | 144 ms | 728 ms | 3232 ms |
| queued before the handler ran | 21.5 ms | 195.6 ms | 2938.7 ms |
| inside our handler | 0.0 ms | 0.6 ms | 565 ms |

The handler is a rounding error. The lag is presses stacking behind work already running, so each fix here removes work rather than making a handler faster.

## Issue or approval

Fixes #605.

## Reproduction steps

1. Open a title with several debrid-backed addons enabled, so Sources returns 700+ streams.
2. Hold left/right across the source tabs, then hold down through the stream list.
3. Separately: from Home go to Settings, then back to Home.
4. Separately: open a title where one addon fails and its chip turns red.

## Old behavior

- **Home:** returning rendered 26 rows, rebuilt at 6, then rebuilt at 26 again — three DOM writes, ~880 ms of render, with a visible regression to a stripped-down Home in between.
- **Source tabs:** switching carried the previous row index into the new filter, selecting an unrelated stream and scrolling the list to wherever that index landed.
- **List navigation:** `applyManualListScroll` cost 7.1 s of self time over 25 presses on a 246-row list and 23 s on a 714-row list (~285 ms and ~920 ms per press).
- **Failing addon:** the chip turning red, and its cleanup 1.6 s later, each went through a full render, rebuilding every stream card twice.

## New behavior

| | before | after |
|---|---|---|
| `applyManualListScroll` self time (25 presses) | 7.1 s @ 246 rows | absent from the profile |
| `setListScrollTop` per press | ~113 ms @ 926 rows | ~72 ms |
| `render` self time during navigation | 455 ms | 203 ms |
| Home return | 26 → 6 → 26 rows, 3 DOM writes | row set preserved |
| Source tab switch | jumps to carried-over index | starts at the top |

Some of that improvement is c6addde landing in parallel; the manual-scroll and layout-flush numbers are from this branch.

## Platform impact

- Samsung Tizen: shared code paths only. The manual-scroll change is webOS-gated and cannot alter Tizen. **Not tested on Tizen hardware.**
- LG webOS: where everything was measured (webOS 10.3). Legacy webOS (≤ 6) keeps the manual scroll path and its stylesheet unchanged.
- Browser development mode: `manual-scroll` is never applied off webOS, so the scroll change is inert. The Home fix applies everywhere.
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] TizenBrew wrapper support changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- **Virtualising the Sources list is deliberately not here.** With ~900 rows in the DOM, any layout touch costs proportionally, and that floor remains after these fixes. Raised separately as #705 for approval rather than included.
- **`content-visibility: auto` was tested and rejected.** Injected live on-device and A/B profiled on a 458-row list: non-idle main-thread time went from 3108 ms to 5413 ms. Not included.
- **One commit in this branch is a failed attempt, kept deliberately.** `46234b7` moved the manual scroll offset onto a CSS custom property; measured on-device it made per-row cost slightly worse (1.16 → 1.29 ms/row) and the next commit supersedes it. I left it and its result in history rather than rewriting it away — squashing it out on request.
- A filter-render debounce from an earlier revision was dropped during rebase in favour of c6addde's in-place row toggling, which is better.
- No changes to badge hydration, stream fetching, addon resolution, or the player.

## Testing

### Devices / platforms tested

LG C-series, webOS 10.3.1 (Chromium 120), locally packaged build installed over SSH. **Not tested on Samsung Tizen hardware** — I do not have a Tizen device. The one platform-gated change is webOS-only by construction, but the shared Home change is unverified on Tizen.

### Commands tested

```sh
npm test          # 61/61 pass
npx eslint js/ui/screens/home/ js/ui/screens/stream/streamScreen.js   # clean
npx prettier --check <changed files>                                  # clean
npm run package:webos
```

## Manual test flow

Each fix was verified by CPU profiling and `PerformanceObserver` (`longtask` / `event`) over the DevTools protocol, driving synthetic D-pad presses so runs are repeatable, then confirmed by hand on the TV: holding across source tabs, holding down through a 700+ row list, Settings → Home, and a title with a failing addon.

## Screenshots / Video

Not a UI change — the rendered output is identical; only how often and how much of it is rebuilt changed.

## Logs

Not applicable. No crash or platform API error; the numbers above come from CPU profiles rather than logs.

## Regression risk

What was checked, not assumed:

- `shouldUseManualListScroll` now requires a legacy webOS route. The manual path and its `.legacy-webos`-scoped stylesheet are untouched, so legacy TVs behave exactly as before. Modern webOS falls to the native branch, verified on-device by confirming the list still scrolls and focus stays visible.
- The read-back removed from `setListScrollTop` fed a legacy-only fallback comparing requested against applied. A legacy route now takes the manual branch earlier, so that comparison was unreachable.
- `listScrollTop` stores the requested offset instead of the applied one. These can differ by a few pixels at the very end of a list; the next focus move recomputes from element geometry.
- Merging Home rows could resurrect a catalog disabled in Settings, so retained rows are filtered against the current load's catalog descriptors. Covered by `tests/ui/homeRowMerge.test.mjs`, including the removed-catalog case.
- `refreshSourceChipsOnly` replaces chip nodes, so the cached focus lookup is invalidated and chip-zone focus reapplied. The settle and error paths still use a full render, because loading state and the error message change the cards too.

Residual risk: the Home row merge is shared code and unverified on Tizen; and the webOS major-version boundary between "legacy" and "modern" is inherited from the existing `.legacy-webos` classification rather than re-derived, so a webOS 7–9 device that genuinely needs manual scrolling would regress. I could not test those versions.

## Breaking changes

None.

## Linked issues

Fixes #605. Follow-up proposal: #705.
