### PR TITLE
test(player): ASS fallback diagnostics — NOT a fix

### DIFF
--- a/js/core/player/assSubtitleLoader.js
+++ b/js/core/player/assSubtitleLoader.js
@@ -36,7 +36,7 @@ export function loadAssSubtitleLib() {
     return assLibPromise;
   }
   assLibPromise = (async () => {
-    let lastError = null;
+    const failures = [];
     for (const src of ASS_LIB_SOURCES) {
       try {
         await loadScript(src);
@@ -44,12 +44,12 @@ export function loadAssSubtitleLib() {
         if (constructor) {
           return constructor;
         }
-        lastError = new Error(`ass.js loaded from ${src} without the global ASS constructor`);
+        failures.push(`${src}: loaded without the global ASS constructor`);
       } catch (error) {
-        lastError = error;
+        failures.push(`${src}: ${error?.message || "failed to load"}`);
       }
     }
-    throw lastError || new Error("ass.js failed to load");
+    throw new Error(`ass.js failed to load from all sources (${failures.join("; ")})`);
   })();
   try {
     return assLibPromise;

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -12813,10 +12813,21 @@ export const PlayerScreen = {
     }
     this.assSubtitleRenderer = renderer;
     const result = await renderer.init();
+    if (!result.ok) {
+      console.warn("ASS renderer failed to activate, using plain-text fallback", {
+        error: result.error || "ass-renderer-unknown",
+        detail: result.detail || ""
+      });
+    }
     if (!result.ok || !isCurrentSelection()) {
       const fallbackVtt = convertAssBodyToVtt(body);
       this.destroyAssSubtitleRenderer(renderer);
-      return { applied: false, fallbackVtt };
+      return {
+        applied: false,
+        fallbackVtt,
+        error: result.error || null,
+        detail: result.detail || null
+      };
     }
     renderer.setDelay(this.subtitleDelayMs);
     this.showAssSubtitleContainer();
@@ -13342,7 +13353,16 @@ export const PlayerScreen = {
           this.renderSubtitleDialog();
           return true;
         }
-        // ass.js unavailable or stale: plain-text VTT fallback below.
+        // ass.js unavailable, failed, or stale: plain-text VTT fallback below.
+        if (!assResult.applied) {
+          console.warn("ASS addon subtitle fell back to plain text (tv-html path)", {
+            subtitleUrl: sourceUrl,
+            error:
+              assResult.error ||
+              (isCurrentSelection() ? "ass-renderer-unknown" : "ass-renderer-stale"),
+            detail: assResult.detail || ""
+          });
+        }
         const fallbackCues = this.parseSubtitleCues(assResult.fallbackVtt || "");
         if (fallbackCues.length && isCurrentSelection()) {
           this.clearMountedExternalSubtitleTracks();
@@ -15030,9 +15050,7 @@ export const PlayerScreen = {
       ? "html"
       : PlayerController.getAvPlaySubtitleOutputMode?.() || "none";
     const usingWebOsNative = Boolean(
-      Environment.isWebOS() &&
-        PlayerController.isUsingNativePlayback?.() &&
-        !htmlRendererActive
+      Environment.isWebOS() && PlayerController.isUsingNativePlayback?.() && !htmlRendererActive
     );
     const availability = resolveSubtitleStyleControlAvailability({
       isTizenAvPlay: usingTizenAvPlay,
@@ -15691,6 +15709,15 @@ export const PlayerScreen = {
           return;
         }
         assFallbackVtt = assResult.fallbackVtt || "";
+        if (!assResult.applied) {
+          console.warn("ASS addon subtitle fell back to plain text (video-element path)", {
+            subtitleUrl: subtitle.url,
+            error:
+              assResult.error ||
+              (isCurrentSelection() ? "ass-renderer-unknown" : "ass-renderer-stale"),
+            detail: assResult.detail || ""
+          });
+        }
       }
     } catch (assError) {
       if (!isCurrentSelection()) {

--- a/tests/core/player/assSubtitleLoader.test.mjs
+++ b/tests/core/player/assSubtitleLoader.test.mjs
@@ -8,7 +8,7 @@ import { loadStreamingLibs, warmStreamingLibs } from "../../../js/runtime/loadSt
 
 const requestLog = [];
 
-function installDocument({ failSources = [], assStub = null } = {}) {
+function installDocument({ failSources = [], assStub = null, eventErrors = false } = {}) {
   globalThis.document = {
     createElement() {
       return {
@@ -24,7 +24,11 @@ function installDocument({ failSources = [], assStub = null } = {}) {
         requestLog.push(script.src);
         queueMicrotask(() => {
           if (failSources.some((src) => script.src.includes(src))) {
-            script.onerror?.(new Error(`load failed: ${script.src}`));
+            script.onerror?.(
+              eventErrors
+                ? { type: "error", target: script }
+                : new Error(`load failed: ${script.src}`)
+            );
           } else {
             if (assStub) {
               globalThis.ASS = assStub;
@@ -72,6 +76,28 @@ test("falls back to the CDN when the local asset fails", async () => {
 test("rejects when the constructor never appears", async () => {
   installDocument();
   await assert.rejects(loadAssSubtitleLib(), /ass\.js/);
+});
+
+test("both-source failure names every attempted source", async () => {
+  installDocument({ failSources: ["assets/libs/ass.min.js", "cdn.jsdelivr.net"] });
+  await assert.rejects(loadAssSubtitleLib(), (error) => {
+    assert.match(error.message, /ass\.js failed to load from all sources/);
+    assert.match(error.message, /assets\/libs\/ass\.min\.js: /);
+    assert.match(error.message, /cdn\.jsdelivr\.net\/npm\/assjs@0\.1\.10\/[^:]*: /);
+    return true;
+  });
+});
+
+test("both-source failure survives an Event-like onerror payload", async () => {
+  installDocument({
+    failSources: ["assets/libs/ass.min.js", "cdn.jsdelivr.net"],
+    eventErrors: true
+  });
+  await assert.rejects(loadAssSubtitleLib(), (error) => {
+    assert.match(error.message, /assets\/libs\/ass\.min\.js: failed to load/);
+    assert.match(error.message, /cdn\.jsdelivr\.net\/npm\/assjs@0\.1\.10\/[^:]*: failed to load/);
+    return true;
+  });
 });
 
 test("shares one in-flight promise across concurrent calls", async () => {


### PR DESCRIPTION
**⚠️ This PR is for testing/diagnosis only — it does NOT fix ASS subtitle rendering.**

## Background

Users report ASS addon subtitles rendering bottom-centered like plain subtitles (losing `\pos`/`\an` positioning), with short typesetting cues (e.g. JoJo ゴゴゴ signs) flashing by too fast and covering dialogue. That is exactly what the plain-text VTT fallback produces — `convertAssBodyToVtt` strips all override tags.

The pipeline itself is sound: a harness running the real assjs 0.1.10 through the app's actual modules (`isAssSubtitle` → `createAssRenderer`) renders `\pos`, `\move`, karaoke, and drawings at correct coordinates in Chromium. The failure happens on-device (webOS 25 / LG C3) somewhere in renderer activation — and until now, **every failure path was completely silent**:

- `applyAssSubtitleBody()` returned `applied: false` with no logging at either caller
- the ass.js loader rejected with a raw script `Event` whose `.message` is `undefined`

So there was no way to distinguish lib-load failure (local asset 404 vs CDN unreachable) from constructor/parse failure from stale selection.

## What this changes

1. **`assSubtitleLoader.js`** — total load failure now throws an error naming every attempted source:
   `ass.js failed to load from all sources (assets/libs/ass.min.js: …; https://cdn.jsdelivr.net/npm/assjs@0.1.10/…: …)`
2. **`playerScreen.js`** — three previously-silent warnings:
   - `applyAssSubtitleBody` logs `error`/`detail` from `renderer.init()` when activation fails
   - both fallback consumers (tv-html path and video-element path) log the subtitle URL + failure reason when dropping to plain-text VTT
3. **`assSubtitleLoader.test.mjs`** — tests for both-source failure messaging, including the raw-Event onerror shape browsers actually deliver

## Verification

- `npm test`: 57/57 pass (includes the new loader tests)
- `dist/assets/libs/ass.min.js` is byte-identical to the shipped assjs build, and the webOS packaging copies `dist/` wholesale — the local lib ships in the IPK

## What this does NOT do

- Does not change any rendering behavior — the fallback path is preserved exactly as-is
- Does not identify the on-device root cause yet

## Next step

Run on an affected device (LG C3 / webOS 25), reproduce with an ASS track, open **Settings → About → Console debug**, and read the new warning. The `error`/`detail` values (`ass-renderer-load-failed` vs `ass-renderer-parse-failed` vs `ass-renderer-stale`, and which URL failed) will determine the actual fix — which will land in a follow-up PR once captured.