### PR TITLE
fix(player): detect embedded ASS codec for webOS subtitle rendering

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -671,6 +671,20 @@ function normalizeTrackCodecText(value) {
   return cleanDisplayText(value).toUpperCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
 }
 
+function isAssSubtitleCodec(value) {
+  const text = cleanDisplayText(value);
+  if (!text) {
+    return false;
+  }
+  // Matroska codec id (S_TEXT/ASS|SSA), MIME aliases, and short codec names
+  // (ass|ssa) reported by ffprobe / the companion tracks endpoint.
+  return (
+    /^S_TEXT\/(?:ASS|SSA)$/i.test(text) ||
+    /^(?:text\/x-ass|application\/x-ass|text\/x-ssa|application\/x-ssa)$/i.test(text) ||
+    /^(?:ass|ssa|advanced substation alpha|substation alpha)$/i.test(text)
+  );
+}
+
 function isUnsupportedEmbeddedSubtitleTrack(track = {}) {
   const codecText = normalizeTrackCodecText(
     track?.codec || track?.subtitleCodec || track?.codec_name || track?.format || ""
@@ -4374,7 +4388,13 @@ export const PlayerScreen = {
                 .trim()
                 .toUpperCase(),
           forced: isForcedSubtitleTrack(track),
-          codec: cleanDisplayText(track?.codec || track?.subtitleCodec || track?.codec_name),
+          codec: cleanDisplayText(
+            track?.codec ||
+              track?.subtitleCodec ||
+              track?.codec_name ||
+              track?.codecId ||
+              track?.codec_id
+          ),
           format: cleanDisplayText(track?.format || track?.format_name),
           raw: track
         };
@@ -13361,7 +13381,8 @@ export const PlayerScreen = {
         endSeconds: startSeconds + EMBEDDED_TEXT_SUBTITLE_WINDOW_SECONDS,
         includeAssBody:
           this.webOsEmbeddedTextSubtitleUsingAss ||
-          /^S_TEXT\/(?:ASS|SSA)$/i.test(String(track?.codec || ""))
+          isAssSubtitleCodec(track?.codec) ||
+          isAssSubtitleCodec(track?.codec_name)
       });
       if (
         requestToken !== this.webOsEmbeddedTextSubtitleLoadToken ||
@@ -13381,7 +13402,9 @@ export const PlayerScreen = {
         Boolean(assBody) &&
         (this.webOsEmbeddedTextSubtitleUsingAss ||
           windowData.hasAdvancedAssOverrideTags ||
-          /^S_TEXT\/(?:ASS|SSA)$/i.test(String(windowData.codecId || track?.codec || "")));
+          isAssSubtitleCodec(windowData.codecId) ||
+          isAssSubtitleCodec(track?.codec) ||
+          isAssSubtitleCodec(track?.codec_name));
       if (shouldUseAss) {
         const assResult = await this.applyAssSubtitleBody({
           body: assBody,
@@ -13425,9 +13448,16 @@ export const PlayerScreen = {
         this.destroyAssSubtitleRenderer();
         this.webOsEmbeddedTextSubtitleUsingAss = false;
       }
+      const isAssTrack =
+        isAssSubtitleCodec(windowData.codecId) ||
+        isAssSubtitleCodec(track?.codec) ||
+        isAssSubtitleCodec(track?.codec_name) ||
+        Boolean(windowData.assBody);
       const cues = this.parseSubtitleCues(windowData.body);
       const shouldUseHtml =
-        this.webOsEmbeddedTextSubtitleUsingHtml || Boolean(windowData.hasAssOverrideTags);
+        this.webOsEmbeddedTextSubtitleUsingHtml ||
+        Boolean(windowData.hasAssOverrideTags) ||
+        (isAssTrack && cues.length > 0);
       if (!shouldUseHtml || (!cues.length && !this.webOsEmbeddedTextSubtitleUsingHtml)) {
         return false;
       }

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -966,7 +966,12 @@ function uniqueFramesInRange(frames, startMs, endMs) {
 }
 
 function isTextSubtitleTrack(track) {
-  return Boolean(track && track.type === 0x11 && /^S_TEXT\//i.test(String(track.codecId || "")));
+  var codecId = String((track && track.codecId) || "");
+  return Boolean(
+    track &&
+    track.type === 0x11 &&
+    (/^S_TEXT\//i.test(codecId) || isAssSubtitleCodec(codecId))
+  );
 }
 
 function isAssSubtitleCodec(value) {

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -969,8 +969,23 @@ function isTextSubtitleTrack(track) {
   return Boolean(track && track.type === 0x11 && /^S_TEXT\//i.test(String(track.codecId || "")));
 }
 
+function isAssSubtitleCodec(value) {
+  var text = String(value || "").trim();
+  if (!text) return false;
+  return (
+    /^S_TEXT\/(?:ASS|SSA)$/i.test(text) ||
+    /^(?:text\/x-ass|application\/x-ass|text\/x-ssa|application\/x-ssa)$/i.test(text) ||
+    /^(?:ass|ssa|advanced substation alpha|substation alpha)$/i.test(text)
+  );
+}
+
 function isAssTextSubtitleTrack(track) {
-  return Boolean(track && /^S_TEXT\/(?:ASS|SSA)$/i.test(String(track.codecId || "")));
+  return Boolean(
+    track &&
+    (isAssSubtitleCodec(track.codecId) ||
+      isAssSubtitleCodec(track.codecName) ||
+      isAssSubtitleCodec(track.codec_name))
+  );
 }
 
 function isAssTimestamp(value) {
@@ -1045,7 +1060,7 @@ function normalizeTextSubtitlePayload(track, payload) {
     text = textAfterCommaCount(assEvent, 9) || assEvent;
   } else if (hasShortAssTiming) {
     text = textAfterCommaCount(assEvent, fields.length >= 9 ? 8 : 2) || assEvent;
-  } else if (/^S_TEXT\/(?:ASS|SSA)$/i.test(String((track && track.codecId) || ""))) {
+  } else if (isAssTextSubtitleTrack(track)) {
     text = assEvent;
   }
   return text.replace(/\n{2,}/g, "\n").trim();


### PR DESCRIPTION
## Summary

Embedded Matroska ASS/SSA subtitle tracks report a bare codec (`ass`/`ssa`) or `codecId` `S_TEXT/ASS`, but the ASS gates only matched the strict `S_TEXT/(ASS|SSA)` regex. This silently fell back to VTT, dropping positioned cues, and the HTML overlay gate further prevented plain dialogue from rendering. This PR adds a tolerant `isAssSubtitleCodec` predicate used in both the client (`playerScreen.js`) and the webOS companion service (`bitmapSubtitles.js`) gates, and extends track normalization to include `codecId`/`codec_id`/`codec_name`.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [ ] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [x] Playback
- [ ] Audio tracks
- [x] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio WebTV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

On webOS, embedded ASS subtitles were not detected as ASS, so the player fell back to VTT/SRT-style rendering. Positioning tags like `{\an8}` then leaked into the visible subtitle text, and plain dialogue on positioned tracks failed to render at all. This restores correct ASS detection and rendering for embedded ASS tracks on webOS.

## Old behavior

Embedded ASS/SSA tracks with a bare `ass`/`ssa` codec or `codecId` `S_TEXT/ASS` were not matched by the strict `S_TEXT/(ASS|SSA)` regex, so the player treated them as non-ASS, fell back to VTT, and either leaked positioning tag text or failed to render the HTML subtitle overlay.

## New behavior

`isAssSubtitleCodec` matches Matroska codec id (`S_TEXT/ASS|SSA`), MIME aliases (`text/x-ass`, `application/x-ass`, `text/x-ssa`, `application/x-ssa`), and short codec names (`ass`, `ssa`, `advanced substation alpha`, `substation alpha`). The client and webOS companion service use it for ASS detection and track normalization, so embedded ASS tracks render correctly via the ASS path or the HTML overlay.

## Platform impact

- Samsung Tizen: Not affected. The `isAssSubtitleCodec` detection logic and all of its call sites in `playerScreen.js` live inside the webOS-only embedded-subtitle window functions (gated by `Environment.isWebOS()` and `webOsEmbeddedTextSubtitleUsingAss`), and `bitmapSubtitles.js` is the webOS companion service. Tizen uses a separate AVPlay subtitle path and never invokes these gates, so its behavior is unchanged.
- LG webOS: Fixed. Embedded ASS subtitle detection now works in both the client (`playerScreen.js`) and the webOS companion service (`bitmapSubtitles.js`), restoring positioned cue rendering and plain dialogue.
- Browser development mode: No change. The shared `playerScreen.js` gate change only engages on webOS (`windowData.codecId`/companion flow); non-webOS rendering behavior is unchanged.
- Installer / packaging: None.
- Wrapper repositories: None.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio WebTV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [ ] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [ ] I listed the testing performed below.

## Scope boundaries

This is a focused, webOS-only bug fix for embedded ASS subtitle codec detection. It does not add UI, change product direction, refactor unrelated code, alter packaging/installer, or modify Tizen/browser subtitle behavior. No formatting, cleanup, or drive-by changes are bundled.

## Testing

No runtime or manual testing was performed for this change.

The fix is a deterministic, self-contained codec-detection predicate. It was validated by code inspection and reasoning against the known failing inputs: bare `ass`/`ssa` codec names, `S_TEXT/ASS`/`S_TEXT/SSA` `codecId`, and the MIME aliases `text/x-ass`, `application/x-ass`, `text/x-ssa`, `application/x-ssa`.

An external local demo exists at `/tmp/ass-local/` (a static `server.py` plus `index.html` rendering `jjk.mp4` with `jjk-eng.ass` via `ass.global.js`), but it was not executed as part of validating this PR.

### Devices / platforms tested

None.

### Commands tested

```sh
npm run build
```

### Manual test flow

Not executed. No app run or external demo was performed to validate this change.

## Screenshots / Video

Not a UI change — this is a subtitle rendering/detection fix with no UI, layout, focus, or visual changes.

## Logs

None captured. No runtime execution (app or external demo) was performed for this change, so there were no crashes, blank screens, install/package failures, or platform API errors to log.

## Regression risk

- Samsung Tizen: None. The detection predicate is only consumed by webOS subtitle gates; Tizen uses a separate AVPlay subtitle path and never calls them.
- Browser development mode: None. The shared `playerScreen.js` gate change only engages on webOS (`windowData.codecId`/companion flow); non-webOS rendering behavior is unchanged.
- LG webOS: Positive — restores correct embedded ASS detection. Risk is limited to the companion service's `isAssTextSubtitleTrack`/`normalizeTextSubtitlePayload` paths, which now also accept MIME aliases and short codec names in addition to `S_TEXT/ASS|SSA`.

## Breaking changes

None.

## Linked issues

No linked issue — opened without an issue reference per author request.
