### PR TITLE
fix: per-episode rating from addon metadata is never parsed

### DIFF
--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -747,7 +747,8 @@ function addonRatingsBySeason(episodes = []) {
   episodes.forEach((episode) => {
     const season = Number(episode?.season);
     const number = Number(episode?.episode);
-    const rating = normalizeEpisodeImdbRating(episode?.imdbRating);
+    const normalizedRating = normalizeEpisodeImdbRating(episode?.imdbRating);
+    const rating = normalizedRating == null ? null : Number(normalizedRating.toFixed(1));
     if (!Number.isFinite(season) || !Number.isFinite(number) || rating == null) {
       return;
     }
@@ -767,7 +768,14 @@ function mergeSeasonRatings(addon = {}, service = {}) {
   new Set([...Object.keys(addon), ...Object.keys(service)]).forEach((season) => {
     const byEpisode = new Map();
     (addon[season] || []).forEach((entry) => byEpisode.set(Number(entry.episode), entry));
-    (service[season] || []).forEach((entry) => byEpisode.set(Number(entry.episode), entry));
+    (service[season] || []).forEach((entry) => {
+      const episode = Number(entry?.episode);
+      const hasUsableRating = normalizeEpisodeImdbRating(entry?.rating) != null;
+      if (!hasUsableRating && byEpisode.has(episode)) {
+        return;
+      }
+      byEpisode.set(episode, entry);
+    });
     merged[season] = [...byEpisode.values()].sort((l, r) => l.episode - r.episode);
   });
   return merged;

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -207,6 +207,7 @@ function toEpisodeEntry(video = {}) {
       video.imdb_score ??
       video.ratings?.imdb ??
       video.mdbListRatings?.imdb ??
+      video.rating ??
       null
   };
 }
@@ -744,6 +745,39 @@ function resolveImdbRating(meta = {}) {
     return meta.mdbListRatings.imdb;
   }
   return null;
+}
+
+// Ratings the addon supplied on meta.videos[].rating, in the same shape the
+// episode-ratings service returns. Merged under it, so the service still wins.
+function addonRatingsBySeason(episodes = []) {
+  const seasons = {};
+  episodes.forEach((episode) => {
+    const season = Number(episode?.season);
+    const number = Number(episode?.episode);
+    const rating = normalizeEpisodeImdbRating(episode?.imdbRating);
+    if (!Number.isFinite(season) || !Number.isFinite(number) || rating == null) {
+      return;
+    }
+    if (!Array.isArray(seasons[season])) {
+      seasons[season] = [];
+    }
+    seasons[season].push({ episode: number, rating });
+  });
+  Object.keys(seasons).forEach((season) => {
+    seasons[season].sort((left, right) => left.episode - right.episode);
+  });
+  return seasons;
+}
+
+function mergeSeasonRatings(addon = {}, service = {}) {
+  const merged = {};
+  new Set([...Object.keys(addon), ...Object.keys(service)]).forEach((season) => {
+    const byEpisode = new Map();
+    (addon[season] || []).forEach((entry) => byEpisode.set(Number(entry.episode), entry));
+    (service[season] || []).forEach((entry) => byEpisode.set(Number(entry.episode), entry));
+    merged[season] = [...byEpisode.values()].sort((l, r) => l.episode - r.episode);
+  });
+  return merged;
 }
 
 function resolveEpisodeImdbRating(episode = {}, seriesRatingsBySeason = {}) {
@@ -1947,7 +1981,10 @@ export const MetaDetailsScreen = {
         return;
       }
       if (isSeriesDetailMeta(this.meta, this.episodes)) {
-        this.seriesRatingsBySeason = results[0] || {};
+        this.seriesRatingsBySeason = mergeSeasonRatings(
+          addonRatingsBySeason(this.episodes),
+          results[0] || {}
+        );
         if (this.meta?.ids?.trakt && results[1] instanceof Map) {
           this.enrichedWatchedState = results[1];
           this.buildEpisodeState(allProgressItems, allWatchedItems, this.enrichedWatchedState);


### PR DESCRIPTION
## Summary

`toEpisodeEntry()` builds each episode's rating from four candidate keys but not `rating`, the one Cinemeta and the TMDB addon actually send. This adds it to that chain and seeds `seriesRatingsBySeason` from the episodes, so both the episode cards and the Ratings panel use it.

## PR type

- [x] Approved feature/change

## Affected area

- [x] Shared web app

## Why

The Android TV equivalent was merged as NuvioMedia/NuvioTV#3139. This is the web half of the same change.

`toEpisodeEntry()` already accepts an addon-supplied per-episode rating under four spellings:

```js
video.imdbRating ?? video.imdb_score ?? video.ratings?.imdb ?? video.mdbListRatings?.imdb ?? null
```

`rating` is missing from that list, and it is the one Cinemeta populates — all 67 videos on Breaking Bad (`tt0903747`) — and that the TMDB addon populates with values like `"8.519"`. So the value arrives and is dropped.

Episode ratings can then only come from the external ratings service, which needs an IMDb or TMDB id. That covers most series, so the gap only shows with addons that use their own ids: `fetchSeriesRatingsBySeason()` resolves neither id, returns `{}`, and both the episode cards and the Ratings panel go empty even though the addon sent a rating for every episode.

It is also total in a build from source, where `IMDB_RATINGS_API_BASE_URL` and `IMDB_TAPFRAME_API_BASE_URL` are empty in `local.example.properties` and the service returns nothing for any series.

## Issue or approval

NuvioMedia/NuvioWeb#690 was closed with:

> Supporting addon-provided episode ratings would need to be a coordinated cross-platform contract and UX change, with Android TV updated first or alongside Web.

Android TV has now landed: https://github.com/NuvioMedia/NuvioTV/pull/3139 (merged). This is that second half. Desktop and mobile are open as NuvioMedia/NuvioDesktop#443 and NuvioMedia/NuvioMobile#1776.

## Reproduction steps

1. Build from source with the stock `local.example.properties`, so both rating API base URLs are empty.
2. Install the Cinemeta addon (default) and open Breaking Bad.
3. Open the season 1 episode list — no rating on any card.
4. Open the Ratings panel — "Ratings not available."
5. Check the Cinemeta response in DevTools: every entry in `meta.videos[]` has a `rating`.

## Old behavior

`rating` was discarded in `toEpisodeEntry()`. Episode ratings came only from the external service, so any series it could not resolve showed none — on the cards and in the Ratings panel — even when the addon supplied one for every episode.

## New behavior

`video.rating` is read as the last entry in the existing chain, and `seriesRatingsBySeason` is seeded from the episodes before the service result is merged over it. The service still wins wherever it returns a value; the addon only fills what it does not cover.

## Platform impact

Shared web app only. No Tizen, webOS, browser-mode or wrapper-specific code is touched.

## UI / behavior / playback impact

- [x] Behavior change has explicit maintainer approval
- [x] No playback change

The rating badge and the Ratings panel already exist and already render whenever the service returns values. This only fills them when it returns none, so no layout changes.

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

One file. Deliberately not included:

- No change to `imdbEpisodeRatingsRepository` or to how the service is called. It keeps priority — the merge puts the service result on the right, so it overrides the addon per episode.
- No new UI, no layout or styling changes.
- No change to rating formatting. `normalizeEpisodeImdbRating` and the existing badge already handle it, so the three-decimal values the TMDB addon sends render as `8.5`.
- Android TV merged as NuvioMedia/NuvioTV#3139; desktop and mobile are NuvioMedia/NuvioDesktop#443 and NuvioMedia/NuvioMobile#1776. Nothing here depends on those.

## Testing

`npm run build` then `npm run serve`, on a source build where both rating API base URLs are empty so the service returns nothing.

- Breaking Bad — no ratings before, 67 episodes rated after, from Cinemeta's `meta.videos[].rating`.
- Stranger Things — no ratings before or after. Cinemeta sends `"rating": "0"` for all 70 of its videos, and `normalizeEpisodeImdbRating()` already drops anything not `> 0`, so unrated series are unaffected.
- An addon using its own ids — ratings on the cards and in the Ratings panel, where neither could show anything before.

I checked metadata display only, not playback.

## Manual test flow

Open a series → Episodes → check the badges → open the Ratings panel → confirm the same values per season.

## Screenshots / Video

Both from a source build with the stock `local.example.properties`, so the rating API base URLs are empty and the service returns nothing.

Breaking Bad before the change — no badge on any episode card, and the Ratings tab says "Ratings not available". Cinemeta sends a `rating` for all 67 of its videos:

<img width="2560" height="1247" alt="1" src="https://github.com/user-attachments/assets/455ab033-b5ac-4f28-b3f4-40dd8e3257a0" />

After. Both views read `seriesRatingsBySeason`, so seeding it fixes them together:

<img width="2560" height="1247" alt="2" src="https://github.com/user-attachments/assets/18843e30-c12b-49fd-a90a-d5c98a97d7a5" />

## Logs

Not applicable — no crash, blank screen or platform API error. The difference is visible by comparing the Cinemeta network response with what the cards render.

## Regression risk

Low. The addon value is read only where the service returned nothing, so any series it covers is unchanged. A failed or timed-out fetch already resolves to `{}` before the merge, so the addon half survives rather than being wiped.

## Breaking changes

None.

## Linked issues

NuvioMedia/NuvioWeb#690
