### PR TITLE
fix(subtitles): correct ASS rendering and raw control field leaks

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -11658,6 +11658,34 @@ html.legacy-webos .debug-console-log-frame {
 .player-ass-subtitles.hidden {
   display: none;
 }
+.player-ass-subtitles .ASS-box {
+  position: absolute;
+  overflow: hidden;
+  pointer-events: none;
+  font-family: Arial, sans-serif;
+}
+
+.player-ass-subtitles .ASS-dialogue {
+  position: absolute;
+  z-index: 0;
+  display: block;
+  box-sizing: content-box;
+  width: max-content;
+  font-size: 0;
+  transform: translate(calc(var(--ass-align-h) * -1), calc(var(--ass-align-v) * -1));
+}
+
+.player-ass-subtitles .ASS-dialogue span {
+  display: inline-block;
+}
+
+.player-ass-subtitles .ASS-dialogue [data-text] {
+  display: inline-block;
+  color: var(--ass-fill-color);
+  font-size: calc(var(--ass-scale) * var(--ass-real-fs) * 1px);
+  line-height: calc(var(--ass-scale) * var(--ass-tag-fs) * 1px);
+  letter-spacing: calc(var(--ass-scale) * var(--ass-tag-fsp) * 1px);
+}
 
 .player-html-subtitle-cue {
   position: absolute;

--- a/js/core/player/assRenderer.js
+++ b/js/core/player/assRenderer.js
@@ -39,7 +39,9 @@ function debugAssRender(stage, details = {}) {
 function hasRawAssControlText(container) {
   const text = String(container?.textContent || "");
   return (
-    /(?:^|\n)\s*(?:Dialogue|Comment)\s*:/i.test(text) ||
+    // Require the SSA field shape so legitimate cue text that merely starts
+    // with "Dialogue:"/"Comment:" does not tear down the whole renderer.
+    /(?:^|\n)\s*(?:Dialogue|Comment)\s*:\s*\d+\s*,\s*\d+:\d{1,2}:\d{1,2}[.,]/i.test(text) ||
     /(?:^|\n)\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(text)
   );
 }

--- a/js/core/player/assRenderer.js
+++ b/js/core/player/assRenderer.js
@@ -25,6 +25,25 @@ function clearContainer(container) {
   }
 }
 
+function debugAssRender(stage, details = {}) {
+  if (!globalThis.__NUVIO_DEBUG_ASS__) {
+    return;
+  }
+  try {
+    console.info(`[Nuvio ASS] ${stage}`, details);
+  } catch (_) {
+    // Debug logging must never affect playback.
+  }
+}
+
+function hasRawAssControlText(container) {
+  const text = String(container?.textContent || "");
+  return (
+    /(?:^|\n)\s*(?:Dialogue|Comment)\s*:/i.test(text) ||
+    /(?:^|\n)\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(text)
+  );
+}
+
 export function createAssRenderer({
   body,
   video,
@@ -81,7 +100,44 @@ export function createAssRenderer({
         };
       }
       try {
-        instance = new AssConstructor(String(body), video, { container, resampling });
+        const sourceBody = String(body)
+          .replace(/^\uFEFF/, "")
+          .replace(/\0/g, "");
+        const hasEvents = /^\s*\[Events\]\s*$/im.test(sourceBody);
+        const dialogueCount = (sourceBody.match(/^\s*Dialogue\s*:/gim) || []).length;
+        debugAssRender("construct", {
+          token,
+          length: sourceBody.length,
+          hasEvents,
+          dialogueCount
+        });
+        // ass.js only parses Dialogue rows inside an [Events] section. A
+        // headerless body would construct an empty renderer and report ok,
+        // so reject it here and let the caller fall back to VTT.
+        if (!hasEvents || !dialogueCount) {
+          clearContainer(container);
+          return {
+            ok: false,
+            error: "ass-renderer-empty-script",
+            detail: "ASS body lacks an [Events] section with Dialogue rows"
+          };
+        }
+        instance = new AssConstructor(sourceBody, video, { container, resampling });
+        debugAssRender("constructed", {
+          token,
+          childCount: Number(container.childNodes?.length || 0),
+          text: String(container.textContent || "").slice(0, 240)
+        });
+        if (hasRawAssControlText(container)) {
+          instance.destroy?.();
+          instance = null;
+          clearContainer(container);
+          return {
+            ok: false,
+            error: "ass-renderer-raw-control-text",
+            detail: "ass.js exposed ASS control fields as visible text"
+          };
+        }
       } catch (error) {
         instance = null;
         clearContainer(container);

--- a/js/core/player/assRenderer.js
+++ b/js/core/player/assRenderer.js
@@ -40,9 +40,9 @@ function hasRawAssControlText(container) {
   const text = String(container?.textContent || "");
   return (
     // Require the SSA field shape so legitimate cue text that merely starts
-    // with "Dialogue:"/"Comment:" does not tear down the whole renderer.
-    /(?:^|\n)\s*(?:Dialogue|Comment)\s*:\s*\d+\s*,\s*\d+:\d{1,2}:\d{1,2}[.,]/i.test(text) ||
-    /(?:^|\n)\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(text)
+    /(?:^|\n)\s*(?:Dialogue|Comment)\s*:\s*(?:\d+|Marked\s*=\s*\d+)\s*,\s*\d+:\d{1,2}:\d{1,2}[.,]/i.test(
+      text
+    ) || /(?:^|\n)\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(text)
   );
 }
 

--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -37,6 +37,10 @@ function hasAssDialogueEvents(normalized) {
   return /^\s*Dialogue\s*:/im.test(normalized) && /^\s*Format\s*:/im.test(normalized);
 }
 
+function hasAssDialoguePayload(normalized) {
+  return /^\s*Dialogue\s*:/im.test(normalized);
+}
+
 /**
  * Detect ASS/SSA subtitle bodies from content and metadata.
  *
@@ -64,7 +68,8 @@ export function isAssSubtitle(body, { sourceUrl = "", contentType = "" } = {}) {
   if (hasAssSectionHeaders(normalized) && hasAssDialogueEvents(normalized)) {
     return true;
   }
-  return fromMetadata && hasAssDialogueEvents(normalized);
+  // Some proxy/AVPlay paths strip ASS section headers but preserve event rows.
+  return hasAssDialogueEvents(normalized) || (fromMetadata && hasAssDialoguePayload(normalized));
 }
 
 function parseAssTimestamp(value) {

--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -41,6 +41,15 @@ function hasAssDialoguePayload(normalized) {
   return /^\s*Dialogue\s*:/im.test(normalized);
 }
 
+// Headerless ASS still carries real event rows: an optional Layer followed by
+// Start and End timestamps. Prose transcripts that merely contain the words
+// "Dialogue:"/"Format:" must not be classified as ASS.
+function hasAssTimestampedDialogue(normalized) {
+  return /^\s*Dialogue\s*:\s*(?:\d+\s*,)?\s*\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}\s*,\s*\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}/im.test(
+    normalized
+  );
+}
+
 /**
  * Detect ASS/SSA subtitle bodies from content and metadata.
  *
@@ -69,7 +78,11 @@ export function isAssSubtitle(body, { sourceUrl = "", contentType = "" } = {}) {
     return true;
   }
   // Some proxy/AVPlay paths strip ASS section headers but preserve event rows.
-  return hasAssDialogueEvents(normalized) || (fromMetadata && hasAssDialoguePayload(normalized));
+  // Require actual ASS timing on headerless bodies so non-ASS text that merely
+  // mentions "Dialogue:" is not routed away from the plain-text path.
+  return (
+    hasAssTimestampedDialogue(normalized) || (fromMetadata && hasAssDialoguePayload(normalized))
+  );
 }
 
 function parseAssTimestamp(value) {

--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -9,8 +9,6 @@ const ASS_SECTION_HEADERS = [
   "[Events]"
 ];
 
-const ASS_CONTENT_TYPES = ["text/x-ssa", "application/x-ssa", "text/x-ass", "application/x-ass"];
-
 function normalizeBody(body) {
   return String(body || "")
     .replace(/^\uFEFF/, "")
@@ -41,32 +39,24 @@ function hasAssDialogueEvents(normalized) {
 // Start and End timestamps. Prose transcripts that merely contain the words
 // "Dialogue:"/"Format:" must not be classified as ASS.
 function hasAssTimestampedDialogue(normalized) {
-  return /^\s*Dialogue\s*:\s*(?:\d+\s*,)?\s*\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}\s*,\s*\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}/im.test(
+  return /^\s*Dialogue\s*:\s*(?:(?:\d+|Marked\s*=\s*\d+)\s*,)?\s*\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}\s*,\s*\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}/im.test(
     normalized
   );
 }
 
 /**
- * Detect ASS/SSA subtitle bodies from content and metadata.
+ * Detect ASS/SSA subtitle bodies from content.
  *
  * A body is ASS when it carries standard section headers on their own lines
- * together with Dialogue/Format event lines, or when URL / content-type
- * metadata says so and the body at least looks like SSA. SRT and VTT bodies
- * are always rejected, as is incidental ASS-like text inside a larger
- * non-ASS body.
+ * together with Dialogue/Format event lines, or when it contains timestamped
+ * Dialogue rows (headerless, incl. Marked=). SRT and VTT bodies are always
+ * rejected, as is incidental ASS-like text inside a larger non-ASS body.
  */
-export function isAssSubtitle(body, { sourceUrl = "", contentType = "" } = {}) {
+export function isAssSubtitle(body) {
   const normalized = normalizeBody(body);
   if (!normalized.trim()) {
     return false;
   }
-  const fromMetadata =
-    /\.(ass|ssa)(\?|#|$)/i.test(String(sourceUrl || "")) ||
-    ASS_CONTENT_TYPES.some((type) =>
-      String(contentType || "")
-        .toLowerCase()
-        .includes(type)
-    );
   if (looksLikeSrtOrVtt(normalized)) {
     return false;
   }

--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -37,10 +37,6 @@ function hasAssDialogueEvents(normalized) {
   return /^\s*Dialogue\s*:/im.test(normalized) && /^\s*Format\s*:/im.test(normalized);
 }
 
-function hasAssDialoguePayload(normalized) {
-  return /^\s*Dialogue\s*:/im.test(normalized);
-}
-
 // Headerless ASS still carries real event rows: an optional Layer followed by
 // Start and End timestamps. Prose transcripts that merely contain the words
 // "Dialogue:"/"Format:" must not be classified as ASS.
@@ -80,9 +76,7 @@ export function isAssSubtitle(body, { sourceUrl = "", contentType = "" } = {}) {
   // Some proxy/AVPlay paths strip ASS section headers but preserve event rows.
   // Require actual ASS timing on headerless bodies so non-ASS text that merely
   // mentions "Dialogue:" is not routed away from the plain-text path.
-  return (
-    hasAssTimestampedDialogue(normalized) || (fromMetadata && hasAssDialoguePayload(normalized))
-  );
+  return hasAssTimestampedDialogue(normalized);
 }
 
 function parseAssTimestamp(value) {

--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -1,5 +1,7 @@
 import { getSubtitleAssAlignment, getSubtitleAssAlignmentSettings } from "./subtitleCueLayout.js";
 
+const ASS_CONTENT_TYPES = ["text/x-ssa", "application/x-ssa", "text/x-ass", "application/x-ass"];
+
 const ASS_SECTION_HEADERS = [
   "[Script Info]",
   "[V4+ Styles]",
@@ -45,17 +47,28 @@ function hasAssTimestampedDialogue(normalized) {
 }
 
 /**
- * Detect ASS/SSA subtitle bodies from content.
+ * Detect ASS/SSA subtitle bodies from content and metadata.
  *
  * A body is ASS when it carries standard section headers on their own lines
- * together with Dialogue/Format event lines, or when it contains timestamped
+ * together with Dialogue/Format event lines, when URL/content-type
+ * indicates ASS (.ass/.ssa, text/x-ass), or when it contains timestamped
  * Dialogue rows (headerless, incl. Marked=). SRT and VTT bodies are always
  * rejected, as is incidental ASS-like text inside a larger non-ASS body.
  */
-export function isAssSubtitle(body) {
+export function isAssSubtitle(body, { sourceUrl = "", contentType = "" } = {}) {
   const normalized = normalizeBody(body);
   if (!normalized.trim()) {
     return false;
+  }
+  const fromMetadata =
+    /\.(ass|ssa)(\?|#|$)/i.test(String(sourceUrl || "")) ||
+    ASS_CONTENT_TYPES.some((type) =>
+      String(contentType || "")
+        .toLowerCase()
+        .includes(type)
+    );
+  if (fromMetadata) {
+    return true;
   }
   if (looksLikeSrtOrVtt(normalized)) {
     return false;

--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -67,11 +67,14 @@ export function isAssSubtitle(body, { sourceUrl = "", contentType = "" } = {}) {
         .toLowerCase()
         .includes(type)
     );
-  if (fromMetadata) {
-    return true;
-  }
+  // Prefer an unambiguous body signature over a stale or incorrect URL/MIME
+  // hint. This matches Android's body-first sniffing and keeps a VTT/SRT
+  // response usable even when an addon labels the download as `.ass`.
   if (looksLikeSrtOrVtt(normalized)) {
     return false;
+  }
+  if (fromMetadata) {
+    return true;
   }
   if (hasAssSectionHeaders(normalized) && hasAssDialogueEvents(normalized)) {
     return true;
@@ -80,6 +83,41 @@ export function isAssSubtitle(body, { sourceUrl = "", contentType = "" } = {}) {
   // Require actual ASS timing on headerless bodies so non-ASS text that merely
   // mentions "Dialogue:" is not routed away from the plain-text path.
   return hasAssTimestampedDialogue(normalized);
+}
+
+const DEFAULT_ASS_DIALOGUE_FORMAT = [
+  "layer",
+  "start",
+  "end",
+  "style",
+  "name",
+  "marginl",
+  "marginr",
+  "marginv",
+  "effect",
+  "text"
+];
+
+function isAssEventFormat(fields) {
+  return fields.includes("start") && fields.includes("end") && fields.includes("text");
+}
+
+function inferHeaderlessAssFormat(rest) {
+  const fields = String(rest || "").split(",");
+  if (
+    Number.isFinite(parseAssTimestamp(fields[0])) &&
+    Number.isFinite(parseAssTimestamp(fields[1]))
+  ) {
+    return ["start", "end", "text"];
+  }
+  if (
+    /^(?:\d+|Marked\s*=\s*\d+)$/i.test(String(fields[0] || "").trim()) &&
+    Number.isFinite(parseAssTimestamp(fields[1])) &&
+    Number.isFinite(parseAssTimestamp(fields[2]))
+  ) {
+    return DEFAULT_ASS_DIALOGUE_FORMAT;
+  }
+  return null;
 }
 
 function parseAssTimestamp(value) {
@@ -397,16 +435,25 @@ export function convertAssDialogueToVttCues(body) {
     const trimmed = line.trim();
     if (/^Format\s*:/i.test(trimmed)) {
       const section = trimmed.slice(trimmed.indexOf(":") + 1);
-      formatFields = section.split(",").map((field) => field.trim().toLowerCase());
+      const candidateFields = section.split(",").map((field) => field.trim().toLowerCase());
+      // ASS style sections also contain a `Format:` line. Keep only an event
+      // format here so a headerless body can still be inferred safely.
+      if (isAssEventFormat(candidateFields)) {
+        formatFields = candidateFields;
+      }
       return;
     }
-    if (!/^Dialogue\s*:/i.test(trimmed) || !formatFields) {
+    if (!/^Dialogue\s*:/i.test(trimmed)) {
       return;
     }
     let rest = trimmed.slice(trimmed.indexOf(":") + 1);
+    const eventFormatFields = formatFields || inferHeaderlessAssFormat(rest);
+    if (!eventFormatFields) {
+      return;
+    }
     const values = [];
-    const textIndex = formatFields.indexOf("text");
-    const headCount = textIndex >= 0 ? textIndex : formatFields.length;
+    const textIndex = eventFormatFields.indexOf("text");
+    const headCount = textIndex >= 0 ? textIndex : eventFormatFields.length;
     for (let index = 0; index < headCount; index += 1) {
       const commaIndex = rest.indexOf(",");
       if (commaIndex < 0) {
@@ -417,7 +464,7 @@ export function convertAssDialogueToVttCues(body) {
     }
     values.push(rest);
     const record = {};
-    formatFields.forEach((field, index) => {
+    eventFormatFields.forEach((field, index) => {
       record[field] = values[index];
     });
     const start = parseAssTimestamp(record.start);

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -12957,13 +12957,16 @@ export const PlayerScreen = {
 
   createSubtitleObjectUrl(body, sourceUrl = "", contentType = "") {
     const normalizedContentType = String(contentType || "").toLowerCase();
+    const assBody = isAssSubtitle(body, { sourceUrl, contentType: normalizedContentType });
     const shouldConvertToVtt =
       this.isLikelySrtSubtitleUrl(sourceUrl) ||
       normalizedContentType.includes("subrip") ||
       (!normalizedContentType.includes("vtt") && !/^\s*WEBVTT/i.test(body));
-    const vttText = shouldConvertToVtt
-      ? this.convertSrtToVtt(body)
-      : this.applySubtitleAssAlignmentToVtt(body);
+    const vttText = assBody
+      ? convertAssBodyToVtt(body)
+      : shouldConvertToVtt
+        ? this.convertSrtToVtt(body)
+        : this.applySubtitleAssAlignmentToVtt(body);
     const objectUrl = URL.createObjectURL(new Blob([vttText], { type: "text/vtt" }));
     this.externalSubtitleObjectUrls.push(objectUrl);
     return objectUrl;
@@ -13994,6 +13997,20 @@ export const PlayerScreen = {
     render();
   },
 
+  isAvPlaySubtitleControlPayload(value = "") {
+    const text = String(value || "").trim();
+    if (!text || /[.!?\u00C0-\u024F]/.test(text)) {
+      return false;
+    }
+    if (/^\s*(?:Dialogue|Comment)\s*:/i.test(text)) {
+      return true;
+    }
+    // AVPlay may expose SSA fields as a CSV row instead of its final text.
+    // Require the numeric prefix and at least the structural field count so
+    // ordinary comma-containing dialogue remains valid.
+    return /^\s*\d+\s*,\s*\d+\s*,\s*[\w/.-]+\s*,/.test(text) && text.split(",").length >= 6;
+  },
+
   renderAvPlaySubtitleChange(detail = {}) {
     if (
       !Environment.isTizen() ||
@@ -14017,11 +14034,14 @@ export const PlayerScreen = {
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/\r\n/g, "\n")
       .replace(/\r/g, "\n");
+    // Samsung AVPlay can expose SSA/ASS fields instead of dialogue text.
+    // Never project that control payload into the video overlay.
     const text = this.parseSubtitleCueText(rawText);
-    if (!text) {
+    if (!text || this.isAvPlaySubtitleControlPayload(rawText)) {
       this.renderHtmlSubtitleOverlayCue([]);
       return;
     }
+
     this.htmlSubtitleCues = [];
     this.htmlSubtitleSelectedId = "avplay-native";
     const alignment = this.getSubtitleAssAlignment(rawText);

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -13999,11 +13999,17 @@ export const PlayerScreen = {
 
   isAvPlaySubtitleControlPayload(value = "") {
     const text = String(value || "").trim();
-    if (!text || /[.!?\u00C0-\u024F]/.test(text)) {
+    if (!text) {
       return false;
     }
+    // Check the control prefix before the punctuation heuristic: full SSA
+    // events contain "." inside their H:MM:SS.cc timestamps, which would
+    // otherwise short-circuit to false and let raw fields reach the overlay.
     if (/^\s*(?:Dialogue|Comment)\s*:/i.test(text)) {
       return true;
+    }
+    if (/[.!?\u00C0-\u024F]/.test(text)) {
+      return false;
     }
     // AVPlay may expose SSA fields as a CSV row instead of its final text.
     // Require the numeric prefix and at least the structural field count so

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14002,21 +14002,25 @@ export const PlayerScreen = {
     if (!text) {
       return false;
     }
-    // Check the control prefix before the punctuation heuristic: full SSA
-    // events contain "." inside their H:MM:SS.cc timestamps, which would
-    // otherwise short-circuit to false and let raw fields reach the overlay.
-    if (/^\s*(?:Dialogue|Comment)\s*:/i.test(text)) {
+    // AVPlay may expose the complete SSA event or its positional CSV fields.
+    // Strip only the control prefix for structural validation; plain cue text
+    // such as "Dialogue: hello" must remain renderable.
+    const payload = text.replace(/^\s*(?:Dialogue|Comment)\s*:\s*/i, "");
+    const hasAssTiming =
+      /^(?:(?:\d+|Marked\s*=\s*\d+)\s*,\s*)?\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}\s*,\s*\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}\s*,/i.test(
+        payload
+      );
+    if (hasAssTiming) {
       return true;
     }
     if (/[.!?\u00C0-\u024F]/.test(text)) {
       return false;
     }
-    // AVPlay may expose SSA fields as a CSV row instead of its final text.
-    // Require the numeric prefix and at least the structural field count so
-    // ordinary comma-containing dialogue remains valid.
+    // Require the numeric prefix and a known AVPlay style token so ordinary
+    // comma-containing dialogue remains valid.
     return (
-      /^\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(text) &&
-      text.split(",").length >= 6
+      /^\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(payload) &&
+      payload.split(",").length >= 6
     );
   },
 

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14014,7 +14014,10 @@ export const PlayerScreen = {
     // AVPlay may expose SSA fields as a CSV row instead of its final text.
     // Require the numeric prefix and at least the structural field count so
     // ordinary comma-containing dialogue remains valid.
-    return /^\s*\d+\s*,\s*\d+\s*,\s*[\w/.-]+\s*,/.test(text) && text.split(",").length >= 6;
+    return (
+      /^\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(text) &&
+      text.split(",").length >= 6
+    );
   },
 
   renderAvPlaySubtitleChange(detail = {}) {

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1058,7 +1058,9 @@ function normalizeTextSubtitlePayload(track, payload) {
   if (!text) return "";
 
   var assEvent = text.replace(/^\s*Dialogue\s*:\s*/i, "");
-  if (isRawAssControlPayload(assEvent)) {
+  // ASS-specific heuristic: never apply it to plain SRT/WebVTT/UTF8 text,
+  // where "Comment: ..." or numeric CSV can be legitimate display text.
+  if (isAssTextSubtitleTrack(track) && isRawAssControlPayload(assEvent)) {
     return "";
   }
   var fields = assEvent.split(",");
@@ -1074,11 +1076,10 @@ function normalizeTextSubtitlePayload(track, payload) {
     text = textAfterCommaCount(assEvent, 9) || "";
   } else if (hasShortAssTiming) {
     text = textAfterCommaCount(assEvent, fields.length >= 9 ? 8 : 2) || "";
-  } else if (isAssTextSubtitleTrack(track) && !isRawAssControlPayload(assEvent)) {
-    text = assEvent;
   } else if (isAssTextSubtitleTrack(track)) {
-    return "";
+    text = assEvent;
   }
+
   return text.replace(/\n{2,}/g, "\n").trim();
 }
 
@@ -1221,7 +1222,7 @@ function getAssDialogueText(track, frame) {
 
 function buildAssDialogueLine(track, frame, nextFrame) {
   var text = getAssDialogueText(track, frame);
-  if (!text || isRawAssControlPayload(text)) return "";
+  if (!text) return "";
   var startMs = Number(frame && frame.timestampMs);
   var endMs = getTextCueEndMs(frame, nextFrame);
   if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return "";

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -998,8 +998,13 @@ function isAssTimestamp(value) {
 function isRawAssControlPayload(value) {
   var text = String(value || "").trim();
   if (!text) return false;
-  if (/^\s*(?:Dialogue|Comment)\s*:/i.test(text)) return true;
-  return /^\s*\d+\s*,\s*\d+\s*,\s*[\w/.-]+\s*,/.test(text) && text.split(",").length >= 6;
+  var payload = text.replace(/^\s*(?:Dialogue|Comment)\s*:\s*/i, "");
+  // Timed Dialogue/Comment rows are valid ASS subtitle events and must be
+  // parsed below; only positional AVPlay control CSV is rejected here.
+  return (
+    /^\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(payload) &&
+    payload.split(",").length >= 6
+  );
 }
 
 function parseAssTimestampMs(value) {
@@ -1057,12 +1062,13 @@ function normalizeTextSubtitlePayload(track, payload) {
   var text = decodeTextSubtitlePayload(payload);
   if (!text) return "";
 
-  var assEvent = text.replace(/^\s*Dialogue\s*:\s*/i, "");
-  // ASS-specific heuristic: never apply it to plain SRT/WebVTT/UTF8 text,
-  // where "Comment: ..." or numeric CSV can be legitimate display text.
-  if (isAssTextSubtitleTrack(track) && isRawAssControlPayload(assEvent)) {
+  // Inspect the original payload before removing Dialogue:/Comment: so
+  // structured ASS control rows are filtered without dropping plain cue text.
+  if (isAssTextSubtitleTrack(track) && isRawAssControlPayload(text)) {
     return "";
   }
+  var assEvent = text.replace(/^\s*Dialogue\s*:\s*/i, "");
+  // ASS-specific parsing follows the original-payload control check above.
   var fields = assEvent.split(",");
 
   var hasLayeredAssTiming =

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -995,6 +995,13 @@ function isAssTimestamp(value) {
   return /^\s*\d+:\d{1,2}:\d{1,2}[.:]\d{1,3}\s*$/.test(String(value || ""));
 }
 
+function isRawAssControlPayload(value) {
+  var text = String(value || "").trim();
+  if (!text) return false;
+  if (/^\s*(?:Dialogue|Comment)\s*:/i.test(text)) return true;
+  return /^\s*\d+\s*,\s*\d+\s*,\s*[\w/.-]+\s*,/.test(text) && text.split(",").length >= 6;
+}
+
 function parseAssTimestampMs(value) {
   var match = String(value || "")
     .trim()
@@ -1051,7 +1058,11 @@ function normalizeTextSubtitlePayload(track, payload) {
   if (!text) return "";
 
   var assEvent = text.replace(/^\s*Dialogue\s*:\s*/i, "");
+  if (isRawAssControlPayload(assEvent)) {
+    return "";
+  }
   var fields = assEvent.split(",");
+
   var hasLayeredAssTiming =
     fields.length >= 3 &&
     /^(?:marked\s*=\s*)?-?\d+$/i.test(String(fields[0] || "").trim()) &&
@@ -1060,11 +1071,13 @@ function normalizeTextSubtitlePayload(track, payload) {
   var hasShortAssTiming =
     fields.length >= 3 && isAssTimestamp(fields[0]) && isAssTimestamp(fields[1]);
   if (hasLayeredAssTiming) {
-    text = textAfterCommaCount(assEvent, 9) || assEvent;
+    text = textAfterCommaCount(assEvent, 9) || "";
   } else if (hasShortAssTiming) {
-    text = textAfterCommaCount(assEvent, fields.length >= 9 ? 8 : 2) || assEvent;
-  } else if (isAssTextSubtitleTrack(track)) {
+    text = textAfterCommaCount(assEvent, fields.length >= 9 ? 8 : 2) || "";
+  } else if (isAssTextSubtitleTrack(track) && !isRawAssControlPayload(assEvent)) {
     text = assEvent;
+  } else if (isAssTextSubtitleTrack(track)) {
+    return "";
   }
   return text.replace(/\n{2,}/g, "\n").trim();
 }
@@ -1208,7 +1221,7 @@ function getAssDialogueText(track, frame) {
 
 function buildAssDialogueLine(track, frame, nextFrame) {
   var text = getAssDialogueText(track, frame);
-  if (!text) return "";
+  if (!text || isRawAssControlPayload(text)) return "";
   var startMs = Number(frame && frame.timestampMs);
   var endMs = getTextCueEndMs(frame, nextFrame);
   if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return "";

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1078,10 +1078,26 @@ function normalizeTextSubtitlePayload(track, payload) {
     isAssTimestamp(fields[2]);
   var hasShortAssTiming =
     fields.length >= 3 && isAssTimestamp(fields[0]) && isAssTimestamp(fields[1]);
+  // webOS may strip Start/End and expose the positional form
+  // "Layer,?,Style,Name,MarginL,MarginR,MarginV,Effect,Text" with no
+  // timestamps (e.g. 0,0,Flashback_Italics - Top,News,0,0,0,,text).
+  var hasPositionalAssShape =
+    isAssTextSubtitleTrack(track) &&
+    !hasLayeredAssTiming &&
+    !hasShortAssTiming &&
+    fields.length >= 9 &&
+    /^-?\d+$/.test(String(fields[0] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[1] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[4] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[5] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[6] || "").trim()) &&
+    String(fields[7] || "").trim() === "";
   if (hasLayeredAssTiming) {
     text = textAfterCommaCount(assEvent, 9) || "";
   } else if (hasShortAssTiming) {
     text = textAfterCommaCount(assEvent, fields.length >= 9 ? 8 : 2) || "";
+  } else if (hasPositionalAssShape) {
+    text = textAfterCommaCount(assEvent, 8) || "";
   } else if (isAssTextSubtitleTrack(track)) {
     text = assEvent;
   }


### PR DESCRIPTION
## Summary

Fixes raw ASS/SSA control fields leaking onto the video overlay and incorrect ASS routing across webOS and the shared player path.

### Root causes addressed

1. **webOS positional rows without timestamps** (`0,0,Flashback_Italics - Top,News,0,0,0,,text`): `normalizeTextSubtitlePayload` fell through to `text = assEvent` and projected the raw field prefix. Now a structurally gated branch (ASS track; fields 0,1,4,5,6 numeric; field 7 empty; >=9 fields) extracts the Text field after the 8th comma, preserving commas inside dialogue. Works for any style name — Flashback, Default, or any other.
2. **AVPlay/webOS control CSV** (`533,0,Onscreen1,Screen,0,0,0,,`): `isRawAssControlPayload` drops only rows whose third field is an `Onscreen*`/`Screen` token, evaluated on the original payload before stripping `Dialogue:`. Timed `Dialogue:`/`Comment:` rows flow to the existing parser instead of being dropped.
3. **ASS detection** (`isAssSubtitle`): metadata (`.ass`/`.ssa` URL, ASS content types) is authoritative; otherwise section headers + Dialogue/Format or timestamped Dialogue rows (incl. `Marked=`) qualify. Prose that merely mentions `Dialogue:` is not misclassified.
4. **Renderer guards** (`createAssRenderer`): rejects bodies without `[Events]`/Dialogue rows (`ass-renderer-empty-script`) so callers fall back to VTT, and destroys instances whose container exposes raw SSA field shapes (`ass-renderer-raw-control-text`, incl. `Marked=` layer prefixes).
5. **CSS**: adds the `assjs@0.1.10` `GLOBAL_CSS` subset (`.ASS-box`, `.ASS-dialogue`, `[data-text]` with `--ass-*` vars) scoped to `.player-ass-subtitles` — additive only.

### Verification

- `node --check` on `assSubtitle.js`, `assRenderer.js`, `playerScreen.js`, `bitmapSubtitles.js`
- `npm run build` green
- Smokes: generic/Default/Flashback positional styles → text-only with commas preserved; `Onscreen1/Screen` control rows → dropped; timed ASS → existing parser; plain text → untouched; `Dialogue: hello` / `Comment: hello` → not misclassified

Closes the raw positioning-code leak reported on webOS (`533,0,Onscreen1,Screen,...` stacking and field prefixes like `0,0,Flashback_Italics - Top,...`).
