### PR TITLE
fix(subtitles): extract webOS positional ASS rows without timestamps

### DIFF
--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1283,6 +1283,9 @@ function buildAssDialogueLine(track, frame, nextFrame) {
     String(fields[7] || "").trim() === "";
   var hasStructuredFields = hasShortTiming || hasPositionalShape;
   var assText = text.replace(/\r?\n/g, "\\N");
+  // Positional form carries the ASS Layer in fields[0]; short SSA has none,
+  // so default it to 0. Preserve a non-zero layer to keep stacking order.
+  var layer = hasPositionalShape ? String(fields[0] || "").trim() || "0" : "0";
   var style = hasStructuredFields ? String(fields[2] || "").trim() || "Default" : "Default";
   var name = hasStructuredFields ? String(fields[3] || "").trim() : "";
   var marginL = hasStructuredFields ? String(fields[4] || "").trim() || "0" : "0";
@@ -1290,7 +1293,9 @@ function buildAssDialogueLine(track, frame, nextFrame) {
   var marginV = hasStructuredFields ? String(fields[6] || "").trim() || "0" : "0";
   var effect = hasStructuredFields ? String(fields[7] || "").trim() : "";
   return (
-    "Dialogue: 0," +
+    "Dialogue: " +
+    layer +
+    "," +
     formatAssTimestamp(startMs) +
     "," +
     formatAssTimestamp(endMs) +

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1090,10 +1090,26 @@ function normalizeTextSubtitlePayload(track, payload) {
     isAssTimestamp(fields[2]);
   var hasShortAssTiming =
     fields.length >= 3 && isAssTimestamp(fields[0]) && isAssTimestamp(fields[1]);
+  // webOS may strip Start/End and expose the positional form
+  // "Layer,?,Style,Name,MarginL,MarginR,MarginV,Effect,Text" with no
+  // timestamps (e.g. 0,0,Flashback_Italics - Top,News,0,0,0,,text).
+  var hasPositionalAssShape =
+    isAssTextSubtitleTrack(track) &&
+    !hasLayeredAssTiming &&
+    !hasShortAssTiming &&
+    fields.length >= 9 &&
+    /^-?\d+$/.test(String(fields[0] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[1] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[4] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[5] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[6] || "").trim()) &&
+    String(fields[7] || "").trim() === "";
   if (hasLayeredAssTiming) {
     text = textAfterCommaCount(assEvent, 9) || "";
   } else if (hasShortAssTiming) {
     text = textAfterCommaCount(assEvent, fields.length >= 9 ? 8 : 2) || "";
+  } else if (hasPositionalAssShape) {
+    text = textAfterCommaCount(assEvent, 8) || "";
   } else if (isAssTextSubtitleTrack(track)) {
     text = assEvent;
   }
@@ -1252,13 +1268,45 @@ function buildAssDialogueLine(track, frame, nextFrame) {
     fields[2] = formatAssTimestamp(endMs);
     return "Dialogue: " + fields.slice(0, 9).concat(fields.slice(9).join(",")).join(",");
   }
+  // Short (Start,End,Style,...) and positional (0,0,Style,...) forms both
+  // place Style at index 2. Preserve Style/Name/Margins/Effect so alignment
+  // and typesetting survive; only re-inject real timestamps. Recognize only
+  // those two signatures so arbitrary rows still fall back to Default.
+  var hasShortTiming = fields.length >= 9 && isAssTimestamp(fields[0]) && isAssTimestamp(fields[1]);
+  var hasPositionalShape =
+    fields.length >= 9 &&
+    /^-?\d+$/.test(String(fields[0] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[1] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[4] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[5] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[6] || "").trim()) &&
+    String(fields[7] || "").trim() === "";
+  var hasStructuredFields = hasShortTiming || hasPositionalShape;
   var assText = text.replace(/\r?\n/g, "\\N");
+  var style = hasStructuredFields ? String(fields[2] || "").trim() || "Default" : "Default";
+  var name = hasStructuredFields ? String(fields[3] || "").trim() : "";
+  var marginL = hasStructuredFields ? String(fields[4] || "").trim() || "0" : "0";
+  var marginR = hasStructuredFields ? String(fields[5] || "").trim() || "0" : "0";
+  var marginV = hasStructuredFields ? String(fields[6] || "").trim() || "0" : "0";
+  var effect = hasStructuredFields ? String(fields[7] || "").trim() : "";
   return (
     "Dialogue: 0," +
     formatAssTimestamp(startMs) +
     "," +
     formatAssTimestamp(endMs) +
-    ",Default,,0,0,0,," +
+    "," +
+    style +
+    "," +
+    name +
+    "," +
+    marginL +
+    "," +
+    marginR +
+    "," +
+    marginV +
+    "," +
+    effect +
+    "," +
     assText
   );
 }

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1274,6 +1274,7 @@ function buildAssDialogueLine(track, frame, nextFrame) {
   // those two signatures so arbitrary rows still fall back to Default.
   var hasShortTiming = fields.length >= 9 && isAssTimestamp(fields[0]) && isAssTimestamp(fields[1]);
   var hasPositionalShape =
+    isAssTextSubtitleTrack(track) &&
     fields.length >= 9 &&
     /^-?\d+$/.test(String(fields[0] || "").trim()) &&
     /^-?\d+$/.test(String(fields[1] || "").trim()) &&


### PR DESCRIPTION
## Problem

Follow-up to #735 (merged). On webOS, some ASS cues still render their raw field prefix as visible text:

```
0,0,Flashback_Italics - Top,News,0,0,0,,A large passenger jet crashed into a suburban area early this morning at 9:26 AM.
```

**Root cause:** webOS strips `Start`/`End` from some ASS events and delivers them in positional form. `normalizeTextSubtitlePayload` recognized neither layered (`Layer,Start,End`) nor short (`Start,End`) timing, so it fell through to `text = assEvent` and projected the entire CSV row onto the overlay.

## Change

Single file, +16 lines: `services/webos/src/bitmapSubtitles.js`.

`normalizeTextSubtitlePayload` gains a structurally gated branch — `hasPositionalAssShape` — that requires **all** of:

- ASS track (`isAssTextSubtitleTrack`)
- no layered/short timing (not already covered)
- `fields.length >= 9`
- fields `0`, `1`, `4`, `5`, `6` numeric (Layer, ?, MarginL, MarginR, MarginV)
- field `7` empty (Effect)

then extracts the `Text` field via `textAfterCommaCount(assEvent, 8)`, preserving commas inside dialogue. No style names are hardcoded — `Flashback_Italics`, `Default`, or any other style parse identically.

## Verification

- `node --check`, `eslint`, `prettier --check` green; `npm run build` green
- Smokes (structural replica of the exact logic):
  - `0,0,SomeOtherStyle,Speaker,0,0,0,,A line, with commas` → `A line, with commas`
  - `0,0,Default,Actor,0,0,0,,Hello there` → `Hello there`
  - `0,0,Flashback_Italics - Top,News,0,0,0,,A large, passenger jet` → `A large, passenger jet`
  - `533,0,Onscreen1,Screen,0,0,0,,` → dropped (control row)
  - `Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Timed, line` → existing timed parser, unchanged
  - plain text → unchanged
