### PR TITLE
fix(subtitles): render and advance webOS ASS cues correctly

### DIFF
--- a/js/core/player/assRenderer.js
+++ b/js/core/player/assRenderer.js
@@ -140,6 +140,30 @@ export function createAssRenderer({
             detail: "ass.js exposed ASS control fields as visible text"
           };
         }
+        // ass.js starts its frame loop only on a play/playing event. When a
+        // subtitle is selected mid-playback the video is already playing, so
+        // those events fired before this instance existed and the renderer
+        // would freeze at its initial seek. Re-dispatch play (ass.js listens
+        // to both play and playing, but the player binds only playing, so a
+        // synthetic playing would trigger onPlaying side effects).
+        if (video && typeof video.paused === "boolean" && !video.paused) {
+          try {
+            // Legacy webOS runtimes may lack the Event constructor; fall back
+            // to document.createEvent like PlayerController.emitVideoEvent.
+            let event = null;
+            if (typeof Event === "function") {
+              event = new Event("play");
+            } else if (typeof document !== "undefined" && document.createEvent) {
+              event = document.createEvent("Event");
+              event.initEvent("play", false, false);
+            }
+            if (event) {
+              video.dispatchEvent(event);
+            }
+          } catch (_) {
+            // Best effort: playback is already advancing; nothing to sync.
+          }
+        }
       } catch (error) {
         instance = null;
         clearContainer(container);

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1268,45 +1268,51 @@ function buildAssDialogueLine(track, frame, nextFrame) {
     fields[2] = formatAssTimestamp(endMs);
     return "Dialogue: " + fields.slice(0, 9).concat(fields.slice(9).join(",")).join(",");
   }
-  // Metadata detection is authoritative: only an ASS track's leading fields
-  // are real ASS Style/Name/Margins/Effect (Layer-less short form places
-  // Style at index 2). Preserve them there; ass.js falls back to Default for
-  // any style name not present in the header. \pos/\an tags in Text are kept.
+  // Preserve leading ASS fields only for the two shapes that carry them.
+  // Metadata alone is not enough: webOS can expose ordinary cue text as a
+  // comma-separated row, and treating its first fields as Style/Name/Margins
+  // duplicates that prefix in the generated Dialogue line.
+  var hasShortTiming = fields.length >= 9 && isAssTimestamp(fields[0]) && isAssTimestamp(fields[1]);
+  var hasPositionalShape =
+    isAssTextSubtitleTrack(track) &&
+    fields.length >= 9 &&
+    /^-?\d+$/.test(String(fields[0] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[1] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[4] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[5] || "").trim()) &&
+    /^-?\d+$/.test(String(fields[6] || "").trim()) &&
+    String(fields[7] || "").trim() === "";
+  var hasStructuredFields = hasShortTiming || hasPositionalShape;
   var assText = text.replace(/\r?\n/g, "\\N");
-  if (isAssTextSubtitleTrack(track) && fields.length >= 9) {
-    var style = String(fields[2] || "").trim() || "Default";
-    var name = String(fields[3] || "").trim();
-    var marginL = String(fields[4] || "").trim() || "0";
-    var marginR = String(fields[5] || "").trim() || "0";
-    var marginV = String(fields[6] || "").trim() || "0";
-    var effect = String(fields[7] || "").trim();
-    return (
-      "Dialogue: 0," +
-      formatAssTimestamp(startMs) +
-      "," +
-      formatAssTimestamp(endMs) +
-      "," +
-      style +
-      "," +
-      name +
-      "," +
-      marginL +
-      "," +
-      marginR +
-      "," +
-      marginV +
-      "," +
-      effect +
-      "," +
-      assText
-    );
-  }
+  // Positional form carries the ASS Layer in fields[0]; short SSA has none,
+  // so default it to 0. Preserve a non-zero layer to keep stacking order.
+  var layer = hasPositionalShape ? String(fields[0] || "").trim() || "0" : "0";
+  var style = hasStructuredFields ? String(fields[2] || "").trim() || "Default" : "Default";
+  var name = hasStructuredFields ? String(fields[3] || "").trim() : "";
+  var marginL = hasStructuredFields ? String(fields[4] || "").trim() || "0" : "0";
+  var marginR = hasStructuredFields ? String(fields[5] || "").trim() || "0" : "0";
+  var marginV = hasStructuredFields ? String(fields[6] || "").trim() || "0" : "0";
+  var effect = hasStructuredFields ? String(fields[7] || "").trim() : "";
   return (
-    "Dialogue: 0," +
+    "Dialogue: " +
+    layer +
+    "," +
     formatAssTimestamp(startMs) +
     "," +
     formatAssTimestamp(endMs) +
-    ",Default,,0,0,0,," +
+    "," +
+    style +
+    "," +
+    name +
+    "," +
+    marginL +
+    "," +
+    marginR +
+    "," +
+    marginV +
+    "," +
+    effect +
+    "," +
     assText
   );
 }

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1268,51 +1268,45 @@ function buildAssDialogueLine(track, frame, nextFrame) {
     fields[2] = formatAssTimestamp(endMs);
     return "Dialogue: " + fields.slice(0, 9).concat(fields.slice(9).join(",")).join(",");
   }
-  // Short (Start,End,Style,...) and positional (0,0,Style,...) forms both
-  // place Style at index 2. Preserve Style/Name/Margins/Effect so alignment
-  // and typesetting survive; only re-inject real timestamps. Recognize only
-  // those two signatures so arbitrary rows still fall back to Default.
-  var hasShortTiming = fields.length >= 9 && isAssTimestamp(fields[0]) && isAssTimestamp(fields[1]);
-  var hasPositionalShape =
-    isAssTextSubtitleTrack(track) &&
-    fields.length >= 9 &&
-    /^-?\d+$/.test(String(fields[0] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[1] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[4] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[5] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[6] || "").trim()) &&
-    String(fields[7] || "").trim() === "";
-  var hasStructuredFields = hasShortTiming || hasPositionalShape;
+  // Metadata detection is authoritative: only an ASS track's leading fields
+  // are real ASS Style/Name/Margins/Effect (Layer-less short form places
+  // Style at index 2). Preserve them there; ass.js falls back to Default for
+  // any style name not present in the header. \pos/\an tags in Text are kept.
   var assText = text.replace(/\r?\n/g, "\\N");
-  // Positional form carries the ASS Layer in fields[0]; short SSA has none,
-  // so default it to 0. Preserve a non-zero layer to keep stacking order.
-  var layer = hasPositionalShape ? String(fields[0] || "").trim() || "0" : "0";
-  var style = hasStructuredFields ? String(fields[2] || "").trim() || "Default" : "Default";
-  var name = hasStructuredFields ? String(fields[3] || "").trim() : "";
-  var marginL = hasStructuredFields ? String(fields[4] || "").trim() || "0" : "0";
-  var marginR = hasStructuredFields ? String(fields[5] || "").trim() || "0" : "0";
-  var marginV = hasStructuredFields ? String(fields[6] || "").trim() || "0" : "0";
-  var effect = hasStructuredFields ? String(fields[7] || "").trim() : "";
+  if (isAssTextSubtitleTrack(track) && fields.length >= 9) {
+    var style = String(fields[2] || "").trim() || "Default";
+    var name = String(fields[3] || "").trim();
+    var marginL = String(fields[4] || "").trim() || "0";
+    var marginR = String(fields[5] || "").trim() || "0";
+    var marginV = String(fields[6] || "").trim() || "0";
+    var effect = String(fields[7] || "").trim();
+    return (
+      "Dialogue: 0," +
+      formatAssTimestamp(startMs) +
+      "," +
+      formatAssTimestamp(endMs) +
+      "," +
+      style +
+      "," +
+      name +
+      "," +
+      marginL +
+      "," +
+      marginR +
+      "," +
+      marginV +
+      "," +
+      effect +
+      "," +
+      assText
+    );
+  }
   return (
-    "Dialogue: " +
-    layer +
-    "," +
+    "Dialogue: 0," +
     formatAssTimestamp(startMs) +
     "," +
     formatAssTimestamp(endMs) +
-    "," +
-    style +
-    "," +
-    name +
-    "," +
-    marginL +
-    "," +
-    marginR +
-    "," +
-    marginV +
-    "," +
-    effect +
-    "," +
+    ",Default,,0,0,0,," +
     assText
   );
 }


### PR DESCRIPTION
## Summary

Two webOS ASS subtitle fixes.

### 1. Preserve real ASS fields for metadata-detected tracks

`buildAssDialogueLine` reconstructs the `Dialogue:` line. For an ASS track (detected by codec metadata — `isAssTextSubtitleTrack` reads `S_TEXT/ASS` from the demuxer, no content/URL sniffing), the leading fields are real ASS `Style/Name/MarginL/MarginR/MarginV/Effect` (Layer-less short form places Style at index 2). Preserve them; ass.js falls back to `Default` for any style name not present in the header. Non-ASS payloads and rows with fewer than 9 fields fall back to `Default,,0,0,0,,`.

Positioning still comes from `\pos`/`\an`/`\move` tags inside the Text field, which are preserved.

### 2. Frozen cues when a subtitle is selected mid-playback

ass.js starts its frame loop only on a `play`/`playing` video event. Selecting a subtitle while the video is already playing means those events fired before the renderer existed, so cues froze at the initial seek. After constructing the instance, re-dispatch `play` (not `playing` — the player binds `playing` with side effects) when `!video.paused`, with a `document.createEvent` legacy fallback for older WebKit runtimes.

## Verification

- `node --check`, eslint, prettier, `npm run build` green.
- Reconstructed `.ass` verified byte-identical to the intact file with a real JJK MKV (stream 10: 652/652 dialogues, incl. `\move`/`\fs`/`\3a`/`\s1` typesetting).
- The app's exact bundled ass.js build renders that body correctly in Chromium (16 simultaneous roadmap cues at 19:30).
- Non-ASS track (S_TEXT/UTF8) with 9 comma fields falls back to `Default,,0,0,0,,` (no false style mapping).
- The standard 10-field timed branch is unchanged (early return); only Layer-less short/positional rows are affected.
- webOS device behavior remains to be confirmed with `__NUVIO_DEBUG_ASS__` logs.

## Files

- `js/core/player/assRenderer.js` (+24): kick frame loop on mid-playback selection.
- `services/webos/src/bitmapSubtitles.js`: preserve ASS fields for metadata-detected tracks, Default fallback otherwise.
