### PR TITLE
Fix garbled subtitles when the language is unknown

### DIFF
--- a/js/core/player/subtitleCharsetDetector.js
+++ b/js/core/player/subtitleCharsetDetector.js
@@ -188,8 +188,19 @@ function isFastValidUtf8(bytes) {
   return true;
 }
 
+function decodeCleanly(bytes, charset) {
+  if (typeof TextDecoder !== "function") {
+    return null;
+  }
+  try {
+    return new TextDecoder(charset, { fatal: true }).decode(bytes);
+  } catch (_) {
+    return null;
+  }
+}
+
 function decodeByteRange(bytes, charset, predicate) {
-  const text = decodeWithCharset(bytes, charset);
+  const text = decodeCleanly(bytes, charset);
   if (!text) {
     return 0;
   }


### PR DESCRIPTION
Subtitles with no language tag can show up as random CJK symbols.

The charset auto detect scores each byte sample against Korean and Chinese by decoding it and counting the matching characters. That decode was not strict, so bytes that do not actually fit still produced characters and inflated the score. Hebrew, Russian and Greek subtitles without a language tag were then read as Korean or Chinese and shown as gibberish.

Now the Korean and Chinese scoring decodes strictly and counts nothing when the bytes do not fit, the same way the Android app does with its reporting decoder. The Latin, Cyrillic, Greek and other paths are unchanged.

Checked against the app unit tests for the charset detector. Before and after with no language tag:

Hebrew  before: 驽滹, 溏骧疱 帔 ...   after: correct
Russian before: 橡桠弪 扈 ...        after: correct
Greek   before: 缅獒 筢 ...          after: correct

Hebrew with a hint, Portuguese, Thai and plain UTF-8 all decode exactly as before.