### PR TITLE
Fix garbled symbols and quotes in downloaded subtitles

### DIFF
--- a/js/core/player/subtitleMojibakeSanitizer.js
+++ b/js/core/player/subtitleMojibakeSanitizer.js
@@ -1,0 +1,57 @@
+/**
+ * Sanitizes common character encoding artifacts where UTF-8 subtitle text was interpreted as
+ * Windows-1252 or ISO-8859-1 text (for example, a garbled music note instead of a real one).
+ */
+
+// Longer patterns must precede their shorter fallback prefixes. Patterns use explicit code point
+// escapes because several contain invisible C1 control bytes and non-breaking spaces.
+const REPLACEMENTS = [
+  ["\u00e2\u2122\u00aa", "\u266a"], // â™ª -> ♪
+  ["\u00e2\u2122\u00ab", "\u266b"], // â™« -> ♫
+  ["\u00e2\u20ac\u2122", "\u2019"], // â€™ -> ’
+  ["\u00e2\u20ac\u02dc", "\u2018"], // â€˜ -> ‘
+  ["\u00e2\u20ac\u0153", "\u201c"], // â€œ -> “
+  ["\u00e2\u20ac\u009d", "\u201d"], // â€· -> ”
+  ["\u00e2\u20ac\u009c", "\u201c"], // â€· -> “
+  ["\u00e2\u20ac\u0098", "\u2018"], // â€· -> ‘
+  ["\u00e2\u20ac\u0099", "\u2019"], // â€· -> ’
+  ["\u00e2\u20ac\u201c", "\u2013"], // â€“ -> –
+  ["\u00e2\u20ac\u201d", "\u2014"], // â€” -> —
+  ["\u00e2\u20ac\u00a6", "\u2026"], // â€¦ -> …
+  ["\u00c2\u00a0", " "], // Â␣ -> ␠
+  ["\u00c2\u00bf", "\u00bf"], // Â¿ -> ¿
+  ["\u00c2\u00a1", "\u00a1"], // Â¡ -> ¡
+  ["\u00c2\u00ab", "\u00ab"], // Â« -> «
+  ["\u00c2\u00bb", "\u00bb"], // Â» -> »
+  ["\u00c2 ", " "], // Â␠ -> ␠
+  ["\u00e2\u2122", "\u266a"], // â™ -> ♪
+  ["\u00e2\u20ac", "\u201d"], // â€ -> ”
+  ["\ufffd", ""] // � -> (removed)
+];
+
+function hasPotentialMojibake(text) {
+  for (let index = 0; index < text.length; index++) {
+    const ch = text[index];
+    if (ch === "\u00e2" || ch === "\u00c2" || ch === "\ufffd") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns the text with known mojibake sequences repaired. Text without any of the telltale
+ * marker characters is returned unchanged.
+ */
+export function sanitizeSubtitleMojibake(text) {
+  if (typeof text !== "string" || !hasPotentialMojibake(text)) {
+    return text;
+  }
+  let sanitized = text;
+  for (const [pattern, replacement] of REPLACEMENTS) {
+    if (sanitized.includes(pattern)) {
+      sanitized = sanitized.split(pattern).join(replacement);
+    }
+  }
+  return sanitized;
+}

--- a/js/core/player/subtitleMojibakeSanitizer.test.mjs
+++ b/js/core/player/subtitleMojibakeSanitizer.test.mjs
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeSubtitleMojibake } from "./subtitleMojibakeSanitizer.js";
+
+test("matches the Android sanitizer mappings", () => {
+  const cases = [
+    ["â™ª lalala â™ª", "♪ lalala ♪"],
+    ["â™« song playing â™«", "♫ song playing ♫"],
+    ["â™ melody â™", "♪ melody ♪"],
+    ["Itâ€™s great!", "It’s great!"],
+    ["â€˜Helloâ€™", "‘Hello’"],
+    ["â€œQuoteâ€", "“Quote”"],
+    ["â€œQuoteâ€\u009D", "“Quote”"],
+    ["Wait â€“ what â€” whyâ€¦", "Wait – what — why…"],
+    ["Â¿Cómo estás? Â¡Bien!", "¿Cómo estás? ¡Bien!"],
+    ["Â«HolaÂ»", "«Hola»"],
+    ["HelloÂ world", "Hello world"],
+    ["Hello \uFFFDworld\uFFFD", "Hello world"]
+  ];
+
+  for (const [input, expected] of cases) {
+    assert.equal(sanitizeSubtitleMojibake(input), expected, input);
+  }
+});
+
+test("leaves clean subtitle text unchanged", () => {
+  const clean = "Hello, world! 123 ♪ ♫ “test”";
+  assert.equal(sanitizeSubtitleMojibake(clean), clean);
+});
+
+test("returns non-string input unchanged", () => {
+  assert.equal(sanitizeSubtitleMojibake(null), null);
+  assert.equal(sanitizeSubtitleMojibake(undefined), undefined);
+});

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -109,6 +109,7 @@ import {
 import { isAssSubtitle, convertAssBodyToVtt } from "../../../core/player/assSubtitle.js";
 import { createAssRenderer } from "../../../core/player/assRenderer.js";
 import { decodeSubtitleResponseBody } from "../../../core/player/subtitleCharsetDetector.js";
+import { sanitizeSubtitleMojibake } from "../../../core/player/subtitleMojibakeSanitizer.js";
 import {
   SUBTITLE_VIRTUALIZATION_DEFAULT_ROW_EXTENT,
   SUBTITLE_VIRTUALIZATION_MIN_WINDOW,
@@ -13685,7 +13686,7 @@ export const PlayerScreen = {
         typeof TextDecoder === "function"
           ? await decodeSubtitleResponseBody(response, { languageHint, contentType })
           : null;
-      const body = decodedBody ?? (await response.text());
+      const body = sanitizeSubtitleMojibake(decodedBody ?? (await response.text()));
       return { body, sourceUrl: original, contentType, resolvedUrl: response.url || original };
     } catch (directError) {
       if (Environment.isWebOS()) {
@@ -14850,7 +14851,7 @@ export const PlayerScreen = {
             languageHint: subtitle?.lang || subtitle?.language || subtitle?.languageCode
           })
         : null;
-    const text = decodedText ?? (await response.text());
+    const text = sanitizeSubtitleMojibake(decodedText ?? (await response.text()));
     if (!isCurrentSelection()) {
       return false;
     }

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -13693,7 +13693,7 @@ export const PlayerScreen = {
         try {
           const resolved = await localMediaSubtitleRepository.getExternalSubtitleText(original);
           return {
-            body: resolved.body,
+            body: sanitizeSubtitleMojibake(resolved.body),
             sourceUrl: original,
             contentType: resolved.contentType,
             resolvedUrl: resolved.resolvedUrl || original


### PR DESCRIPTION
## Summary

Downloaded subtitles sometimes show garbage like â™ª for a music note or donâ€™t for don't. This adds a small sanitizer that maps the common bad sequences back to the right characters, ported from the Android app.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [ ] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [x] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Some subtitle files store text that was double encoded, so after a correct decode the text still holds sequences like â™ª and donâ€™t. Nothing on web cleaned these up, so the viewer saw the raw garbage. The Android app already handles this with SubtitleMojibakeSanitizer, so this brings web to the same behavior.

## Issue or approval

No separate issue. This ports the Android SubtitleMojibakeSanitizer for parity. The Android app keeps that component under unit tests, and the web port maps the exact same sequences.

## Reproduction steps

1. Play any title and load an external subtitle whose text was double encoded, for example a line that reads â™ª lalala â™ª or I donâ€™t know.
2. Look at the cues while it plays.

## Old behavior

The cues showed the raw sequences, so a music note read as â™ª and an apostrophe read as donâ€™t.

## New behavior

The same cues now read ♪ lalala ♪ and I don't know. Clean text is returned untouched.

## Platform impact

Shared web code only. No platform specific paths are touched, so every platform gets the fix the same way through the subtitle fetch path.

- Samsung Tizen: no platform code changed
- LG webOS: no platform code changed
- Browser development mode: verified through the shared decode path
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [ ] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the new sanitizer module and its two call sites in the subtitle fetch path. No UI, no playback, no packaging, and no refactors. The sanitizer runs only when the text holds a marker character, so clean subtitles are left exactly as they were.

## Testing

Ran the web sanitizer against every case in the Android SubtitleMojibakeSanitizer unit test and the output matched all of them. Also checked a double encoded sample through the shared decode path before and after, and confirmed clean text is unchanged. Built the web bundle and confirmed the module is included.

### Devices / platforms tested

Chrome on macOS.

### Commands tested

```sh
npm run build
```

## Manual test flow

Loaded a double encoded subtitle sample. Before the change the cues showed â™ª and donâ€™t. After the change they showed ♪ and don't, and lines with no bad characters looked the same as before.

## Screenshots / Video

Not a UI change. Only subtitle text characters are corrected.

## Logs

Not applicable. This only corrects subtitle characters.

## Regression risk

Low. The sanitizer returns the text untouched unless it contains one of the marker characters â, Â, or the replacement character, so normal subtitles are not affected. The replacements match the Android app one for one.

## Breaking changes

None.

## Linked issues

No separate issue. Parity port of the Android SubtitleMojibakeSanitizer.
