### PR TITLE
Keep the real Trakt token lifetime instead of capping it to one day

### DIFF
--- a/js/core/profile/traktCredentialSyncService.js
+++ b/js/core/profile/traktCredentialSyncService.js
@@ -1,6 +1,7 @@
 import { AuthManager } from "../auth/authManager.js";
 import { SupabaseApi } from "../../data/remote/supabase/supabaseApi.js";
 import { TraktAuthStore } from "../../data/local/traktAuthStore.js";
+import { normalizeTraktTokenLifetimeSeconds } from "../../data/local/traktTokenLifetime.js";
 import { ProfileManager } from "./profileManager.js";
 import { getSyncClientId } from "../sync/syncClientIdentity.js";
 
@@ -20,14 +21,6 @@ function resolveProfileId(profileId = null) {
   return 1;
 }
 
-function normalizeLifetimeSeconds(value) {
-  const seconds = Number(value || 0);
-  if (!Number.isFinite(seconds) || seconds <= 0) {
-    return TOKEN_FALLBACK_LIFETIME_SECONDS;
-  }
-  return Math.min(TOKEN_FALLBACK_LIFETIME_SECONDS, Math.trunc(seconds));
-}
-
 function credentialJsonFromState(state = {}) {
   const accessToken = String(state.accessToken || "").trim();
   const refreshToken = String(state.refreshToken || "").trim();
@@ -39,7 +32,9 @@ function credentialJsonFromState(state = {}) {
     refresh_token: refreshToken,
     token_type: String(state.tokenType || "bearer").trim() || "bearer",
     created_at: Number(state.createdAt || Math.floor(Date.now() / 1000)),
-    expires_in: normalizeLifetimeSeconds(state.expiresIn || TOKEN_FALLBACK_LIFETIME_SECONDS)
+    expires_in: normalizeTraktTokenLifetimeSeconds(
+      state.expiresIn || TOKEN_FALLBACK_LIFETIME_SECONDS
+    )
   };
   const username = String(state.username || "").trim();
   const userSlug = String(state.userSlug || "").trim();
@@ -78,7 +73,7 @@ function stateFromCredentialJson(credential = {}) {
     createdAt: Number(
       credential.created_at || credential.createdAt || Math.floor(Date.now() / 1000)
     ),
-    expiresIn: normalizeLifetimeSeconds(
+    expiresIn: normalizeTraktTokenLifetimeSeconds(
       credential.expires_in || credential.expiresIn || TOKEN_FALLBACK_LIFETIME_SECONDS
     ),
     username: credential.username || null,
@@ -92,7 +87,7 @@ function syncSignature(state = {}) {
     state.refreshToken || "",
     state.tokenType || "",
     state.createdAt == null ? "" : String(state.createdAt),
-    state.expiresIn == null ? "" : String(normalizeLifetimeSeconds(state.expiresIn)),
+    state.expiresIn == null ? "" : String(normalizeTraktTokenLifetimeSeconds(state.expiresIn)),
     state.username || "",
     state.userSlug || ""
   ].join("|");

--- a/js/data/local/traktAuthStore.js
+++ b/js/data/local/traktAuthStore.js
@@ -1,8 +1,9 @@
 import { LocalStore } from "../../core/storage/localStore.js";
 import { ProfileManager } from "../../core/profile/profileManager.js";
+import { normalizeTraktTokenLifetimeSeconds } from "./traktTokenLifetime.js";
 
 const STORE_KEY = "traktAuthState";
-const TOKEN_MAX_LIFETIME_SECONDS = 86400;
+const TOKEN_FALLBACK_LIFETIME_SECONDS = 86400;
 
 function activeProfileId() {
   return String(ProfileManager.getActiveProfileId() || "1");
@@ -15,21 +16,13 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-function normalizeLifetimeSeconds(value) {
-  const seconds = Number(value || 0);
-  if (!Number.isFinite(seconds) || seconds <= 0) {
-    return TOKEN_MAX_LIFETIME_SECONDS;
-  }
-  return Math.min(TOKEN_MAX_LIFETIME_SECONDS, Math.trunc(seconds));
-}
-
 function normalizeState(value = {}) {
   return {
     accessToken: String(value.accessToken || "") || null,
     refreshToken: String(value.refreshToken || "") || null,
     tokenType: String(value.tokenType || "") || null,
     createdAt: Number(value.createdAt || 0) || null,
-    expiresIn: value.expiresIn == null ? null : normalizeLifetimeSeconds(value.expiresIn),
+    expiresIn: value.expiresIn == null ? null : normalizeTraktTokenLifetimeSeconds(value.expiresIn),
     username: String(value.username || "") || null,
     userSlug: String(value.userSlug || "") || null,
     deviceCode: String(value.deviceCode || "") || null,
@@ -111,8 +104,8 @@ export const TraktAuthStore = {
       refreshToken: data.refresh_token || data.refreshToken || null,
       tokenType: data.token_type || data.tokenType || "bearer",
       createdAt: Number(data.created_at || data.createdAt || Math.floor(Date.now() / 1000)),
-      expiresIn: normalizeLifetimeSeconds(
-        data.expires_in || data.expiresIn || TOKEN_MAX_LIFETIME_SECONDS
+      expiresIn: normalizeTraktTokenLifetimeSeconds(
+        data.expires_in || data.expiresIn || TOKEN_FALLBACK_LIFETIME_SECONDS
       ),
       deviceCode: null,
       userCode: null,

--- a/js/data/local/traktTokenLifetime.js
+++ b/js/data/local/traktTokenLifetime.js
@@ -1,0 +1,20 @@
+/**
+ * Normalizes a Trakt token lifetime in seconds. An older build forced every token to a one day
+ * lifetime, so a stored value of exactly 86400 is migrated to the documented Trakt lifetime of
+ * seven days. Every other value is kept as is, including the real lifetime Trakt returns and any
+ * invalid value like 0 or a negative number, which is left untouched so the token refreshes right
+ * away. This matches the Android app.
+ */
+
+const TRAKT_LEGACY_FORCED_TOKEN_LIFETIME_SECONDS = 86400;
+const TRAKT_DOCUMENTED_TOKEN_LIFETIME_SECONDS = 604800;
+
+export function normalizeTraktTokenLifetimeSeconds(expiresIn) {
+  const seconds = Math.trunc(Number(expiresIn));
+  if (!Number.isFinite(seconds)) {
+    return 0;
+  }
+  return seconds === TRAKT_LEGACY_FORCED_TOKEN_LIFETIME_SECONDS
+    ? TRAKT_DOCUMENTED_TOKEN_LIFETIME_SECONDS
+    : seconds;
+}

--- a/js/data/local/traktTokenLifetime.test.mjs
+++ b/js/data/local/traktTokenLifetime.test.mjs
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeTraktTokenLifetimeSeconds } from "./traktTokenLifetime.js";
+
+test("legacy forced daily lifetime migrates to the documented lifetime", () => {
+  assert.equal(normalizeTraktTokenLifetimeSeconds(86400), 604800);
+});
+
+test("returned token lifetime is preserved", () => {
+  assert.equal(normalizeTraktTokenLifetimeSeconds(604800), 604800);
+  assert.equal(normalizeTraktTokenLifetimeSeconds(3600), 3600);
+  assert.equal(normalizeTraktTokenLifetimeSeconds(7776000), 7776000);
+});
+
+test("invalid token lifetime is preserved for immediate refresh", () => {
+  assert.equal(normalizeTraktTokenLifetimeSeconds(0), 0);
+  assert.equal(normalizeTraktTokenLifetimeSeconds(-1), -1);
+});
+
+test("numeric strings are accepted and non numbers fall back to zero", () => {
+  assert.equal(normalizeTraktTokenLifetimeSeconds("86400"), 604800);
+  assert.equal(normalizeTraktTokenLifetimeSeconds("604800"), 604800);
+  assert.equal(normalizeTraktTokenLifetimeSeconds(undefined), 0);
+  assert.equal(normalizeTraktTokenLifetimeSeconds("nope"), 0);
+});


### PR DESCRIPTION
## Summary

The web app caps every Trakt token lifetime at one day. A real Trakt token lasts far longer, so the app thinks the token is about to expire and force refreshes it after about a day. This ports the Android behavior, which keeps the real lifetime and only migrates the old forced one day value to the documented seven day lifetime.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

`normalizeLifetimeSeconds` runs `Math.min(86400, value)` on the token lifetime, so a real Trakt lifetime (for example 604800 or 7776000 seconds) is stored as 86400. `isTokenExpiredOrExpiring` then reads that shrunk value and forces a refresh about a day after the token was issued. It also rewrites an invalid lifetime (0 or negative) to 86400 instead of leaving it as is. The Android app keeps the real lifetime, migrates the legacy 86400 value to the documented 604800, and leaves invalid values untouched so the token refreshes right away. The same clamp lives in the Supabase credential sync, so the shrunk value is pushed to the server and pulled back, which keeps re-breaking the value even after a local fix. Both copies are replaced.

## Issue or approval

No linked issue. This matches the Android app, which has a unit test for it (`TraktAuthDataStoreTest`).

## Reproduction steps

1. Connect a Trakt account.
2. Look at the stored token lifetime (or the countdown on the Trakt screen).
3. It reads one day even though Trakt issued a much longer lifetime, so the token is refreshed about a day later.

## Old behavior

Every token lifetime is clamped to 86400 seconds, so a long lived token is treated as a one day token and refreshed too early. Invalid lifetimes are rewritten to 86400.

## New behavior

The real lifetime Trakt returns is kept. A stored legacy value of exactly 86400 migrates to the documented 604800. Invalid values (0 or negative) are kept so the token refreshes immediately. The sync path normalizes the same way, so a shared credential no longer diverges from Android.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the token lifetime normalization changed. The refresh flow, storage shape, and sync RPCs are untouched. No UI changes.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test that mirrors the Android spec.

### Commands tested

```sh
npm run build
node --test js/data/local/traktTokenLifetime.test.mjs
```

## Manual test flow

Ran the exact values from the Android test through the new normalizer: 86400 becomes 604800, 604800 and 3600 and 7776000 are preserved, and 0 and -1 are preserved. Before the fix each of these was clamped or floored to 86400.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low. The normalizer is pure logic with unit tests, and the downstream expiry check already treats 0 as expired, so preserving invalid values just triggers an immediate refresh as before. Storing the real lifetime means the token refreshes near its true expiry instead of a day after issue.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
