### PR TITLE
Clear the Trakt token when a refresh is rejected with 400

### DIFF
--- a/js/data/repository/traktAuthService.js
+++ b/js/data/repository/traktAuthService.js
@@ -7,6 +7,7 @@ import {
 import { TraktAuthStore } from "../local/traktAuthStore.js";
 import { detailWatchedEnrichmentService } from "./detailWatchedEnrichmentService.js";
 import { TraktCredentialSyncService } from "../../core/profile/traktCredentialSyncService.js";
+import { isTraktRefreshTokenRejected } from "./traktRefreshFailure.js";
 
 const API_VERSION = "2";
 const DEFAULT_API_URL = "https://api.trakt.tv";
@@ -219,7 +220,7 @@ export const TraktAuthService = {
     });
 
     if (!response.ok || !payload) {
-      if (response.status === 401 || response.status === 403) {
+      if (isTraktRefreshTokenRejected(response.status)) {
         const recovered = await TraktCredentialSyncService.pullFromRemote();
         if (recovered && TraktAuthStore.get().refreshToken !== state.refreshToken) {
           return this.refreshTokenIfNeeded(true);

--- a/js/data/repository/traktRefreshFailure.js
+++ b/js/data/repository/traktRefreshFailure.js
@@ -1,0 +1,11 @@
+/**
+ * Decides whether a failed Trakt token refresh means the stored refresh token itself is no longer
+ * usable. Trakt replies 400 (invalid_grant) when the refresh token is revoked or expired, and 401
+ * or 403 when it is otherwise rejected. In all three cases the saved credentials are dead, so they
+ * must be cleared and the user asked to reconnect instead of retrying with the same dead token.
+ * This matches the Android app.
+ */
+
+export function isTraktRefreshTokenRejected(status) {
+  return status === 400 || status === 401 || status === 403;
+}

--- a/js/data/repository/traktRefreshFailure.test.mjs
+++ b/js/data/repository/traktRefreshFailure.test.mjs
@@ -1,0 +1,17 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isTraktRefreshTokenRejected } from "./traktRefreshFailure.js";
+
+test("a rejected refresh token clears the credentials", () => {
+  assert.equal(isTraktRefreshTokenRejected(400), true);
+  assert.equal(isTraktRefreshTokenRejected(401), true);
+  assert.equal(isTraktRefreshTokenRejected(403), true);
+});
+
+test("other failures keep the credentials for a later retry", () => {
+  assert.equal(isTraktRefreshTokenRejected(429), false);
+  assert.equal(isTraktRefreshTokenRejected(500), false);
+  assert.equal(isTraktRefreshTokenRejected(502), false);
+  assert.equal(isTraktRefreshTokenRejected(0), false);
+});


### PR DESCRIPTION
## Summary

When a Trakt token refresh fails with HTTP 400, the web app keeps the dead token. Trakt returns 400 (invalid_grant) when the refresh token is revoked or expired, so the app stays "connected" but never works again and keeps retrying the refresh with the same dead token. This ports the Android behavior, which clears the credentials on 400 as well as 401 and 403.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

`refreshTokenIfNeeded` only clears the stored token when the refresh call fails with 401 or 403. A revoked or expired refresh token returns 400 (invalid_grant per RFC 6749), so on 400 the app leaves the dead token in place. The Trakt screen still shows connected, but every later sync, playback, or comments call tries to refresh again and gets another 400, hammering the token endpoint and never recovering. The Android app clears the credentials on 400, 401, and 403, which stops the retries and lets the user reconnect.

## Issue or approval

No linked issue. This matches the Android app, which has a unit test for it (`TraktAuthServiceTest` "refresh token 400 clears credentials and prevents another refresh").

## Reproduction steps

1. Connect a Trakt account.
2. Revoke the app from the Trakt website (or let the refresh token expire).
3. Trigger a token refresh (open a Trakt backed screen).
4. The refresh returns 400 and the app keeps the dead token, so it stays "connected" and keeps retrying.

## Old behavior

On a 400 refresh failure the token is kept, the account still shows connected, and every refresh attempt re-hits the token endpoint with the same dead token.

## New behavior

On a 400 refresh failure the credentials are cleared (after the existing attempt to recover a fresher credential from sync), so the retries stop and the account shows disconnected for the user to reconnect. The next call short circuits because there is no refresh token left.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the refresh failure status check changed. The existing 401 and 403 handling, the sync recovery attempt, and the storage shape are untouched. No UI changes.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test for the status predicate.

### Commands tested

```sh
npm run build
node --test js/data/repository/traktRefreshFailure.test.mjs
```

## Manual test flow

Simulated the refresh failure branch with a 400 response. Before the fix the token is kept and a second refresh hits the endpoint again. After the fix the token is cleared on the first 400 and the second call short circuits, matching the Android test (one refresh call, credentials cleared once).

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low. Only the set of status codes that clear the token changed, from 401/403 to 400/401/403. Other failures (429, 5xx, network) still keep the token for a later retry, so a transient outage does not log the user out.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
