### PR TITLE
Mark a completed Simkl series as watched

### DIFF
--- a/js/data/repository/simklCompletedSeries.js
+++ b/js/data/repository/simklCompletedSeries.js
@@ -1,0 +1,16 @@
+/**
+ * Decides whether a Simkl series entry needs a show level watched marker.
+ *
+ * Simkl can report a whole series as completed while returning no per-episode
+ * watched timestamps, for example a bulk mark or a completion imported from
+ * another service. The Android app emits a show level watched item in that case
+ * so the series still counts as watched. The web app only recorded per-episode
+ * items, so such a completed series never showed as watched and could not be
+ * fixed later by episode reconciliation because there were no watched episodes
+ * to count. This restores the Android behavior. When per-episode history does
+ * exist the per-episode items are enough, so no extra marker is added.
+ */
+
+export function shouldMarkCompletedSeriesWatched(status, hasEpisodeHistory) {
+  return status === "completed" && !hasEpisodeHistory;
+}

--- a/js/data/repository/simklCompletedSeries.test.mjs
+++ b/js/data/repository/simklCompletedSeries.test.mjs
@@ -1,0 +1,19 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldMarkCompletedSeriesWatched } from "./simklCompletedSeries.js";
+
+test("a completed series with no episode history gets a show level marker", () => {
+  assert.equal(shouldMarkCompletedSeriesWatched("completed", false), true);
+});
+
+test("a completed series that already has episode history is not marked again", () => {
+  assert.equal(shouldMarkCompletedSeriesWatched("completed", true), false);
+});
+
+test("a series that is not completed never gets a show level marker", () => {
+  assert.equal(shouldMarkCompletedSeriesWatched("watching", false), false);
+  assert.equal(shouldMarkCompletedSeriesWatched("watching", true), false);
+  assert.equal(shouldMarkCompletedSeriesWatched("hold", false), false);
+  assert.equal(shouldMarkCompletedSeriesWatched("dropped", false), false);
+});

--- a/js/data/repository/simklCompletedSeries.test.mjs
+++ b/js/data/repository/simklCompletedSeries.test.mjs
@@ -3,6 +3,54 @@ import assert from "node:assert/strict";
 
 import { shouldMarkCompletedSeriesWatched } from "./simklCompletedSeries.js";
 
+globalThis.localStorage = (() => {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear()
+  };
+})();
+
+const { LocalStore } = await import("../../core/storage/localStore.js");
+const { SimklSyncService } = await import("./simklSyncService.js");
+const { watchedItemsRepository } = await import("./watchedItemsRepository.js");
+const { watchedSeriesReconciliationService } =
+  await import("./watchedSeriesReconciliationService.js");
+
+SimklSyncService.refresh = async () => false;
+
+const showMedia = {
+  title: "Show",
+  year: 2016,
+  ids: { simkl: 39687, imdb: "tt4574334" }
+};
+
+function seedCompletedSnapshot({ lastWatchedAt = "2024-04-30T22:14:00Z", addedAt = null } = {}) {
+  LocalStore.set("simklSyncState", {
+    version: 1,
+    profiles: {
+      1: {
+        schemaVersion: 2,
+        initialized: true,
+        entries: [
+          {
+            mediaType: "shows",
+            status: "completed",
+            ...(lastWatchedAt == null ? {} : { last_watched_at: lastWatchedAt }),
+            ...(addedAt == null ? {} : { added_to_watchlist_at: addedAt }),
+            show: showMedia
+          }
+        ],
+        playback: [],
+        lastSyncedAt: Date.now(),
+        lastCheckedAt: Date.now()
+      }
+    }
+  });
+}
+
 test("a completed series with no episode history gets a show level marker", () => {
   assert.equal(shouldMarkCompletedSeriesWatched("completed", false), true);
 });
@@ -16,4 +64,58 @@ test("a series that is not completed never gets a show level marker", () => {
   assert.equal(shouldMarkCompletedSeriesWatched("watching", true), false);
   assert.equal(shouldMarkCompletedSeriesWatched("hold", false), false);
   assert.equal(shouldMarkCompletedSeriesWatched("dropped", false), false);
+});
+
+test("completed series without episode history projects a root watched marker", async () => {
+  seedCompletedSnapshot();
+  const watchedItems = await SimklSyncService.getWatchedItems();
+  assert.equal(watchedItems.length, 1);
+  assert.equal(watchedItems[0].contentId, "tt4574334");
+  assert.equal(watchedItems[0].season ?? null, null);
+  assert.equal(watchedItems[0].episode ?? null, null);
+  assert.equal(watchedItems[0].watchedAt, Date.parse("2024-04-30T22:14:00Z"));
+});
+
+test("completed series marker falls back to the watchlist timestamp", async () => {
+  seedCompletedSnapshot({ lastWatchedAt: null, addedAt: "2024-04-29T22:14:00Z" });
+  const watchedItems = await SimklSyncService.getWatchedItems();
+  assert.equal(watchedItems.length, 1);
+  assert.equal(watchedItems[0].watchedAt, Date.parse("2024-04-29T22:14:00Z"));
+});
+
+test("remote Simkl root marker survives incomplete episode reconciliation", async () => {
+  const originalGetAll = watchedItemsRepository.getAll;
+  const originalIsWatched = watchedItemsRepository.isWatched;
+  const originalUnmark = watchedItemsRepository.unmark;
+  let unmarkCalls = 0;
+  watchedItemsRepository.getAll = async () => [
+    {
+      contentId: "tt4574334",
+      contentType: "series",
+      trackingProviderId: "simkl",
+      season: null,
+      episode: null,
+      watchedAt: Date.parse("2024-04-30T22:14:00Z")
+    }
+  ];
+  watchedItemsRepository.isWatched = async () => true;
+  watchedItemsRepository.unmark = async () => {
+    unmarkCalls += 1;
+  };
+  try {
+    const changed = await watchedSeriesReconciliationService.reconcile("tt4574334", "series", {
+      meta: {
+        id: "tt4574334",
+        type: "series",
+        name: "Show",
+        videos: [{ id: "s1e1", season: 1, episode: 1, released: "2024-01-01" }]
+      }
+    });
+    assert.equal(changed, false);
+    assert.equal(unmarkCalls, 0);
+  } finally {
+    watchedItemsRepository.getAll = originalGetAll;
+    watchedItemsRepository.isWatched = originalIsWatched;
+    watchedItemsRepository.unmark = originalUnmark;
+  }
 });

--- a/js/data/repository/simklSyncService.js
+++ b/js/data/repository/simklSyncService.js
@@ -539,10 +539,10 @@ function watchedProjection(snapshot) {
       });
     });
     if (shouldMarkCompletedSeriesWatched(entry.status, hasEpisodeHistory)) {
-      const watchedAt = parseDate(
-        entry.last_watched_at || entry.added_to_watchlist_at,
-        snapshot.lastSyncedAt
-      );
+      const lastWatchedAt = parseDate(entry.last_watched_at, NaN);
+      const watchedAt = Number.isFinite(lastWatchedAt)
+        ? lastWatchedAt
+        : parseDate(entry.added_to_watchlist_at, 0);
       items.push({ ...base, watchedAt });
     }
   });

--- a/js/data/repository/simklSyncService.js
+++ b/js/data/repository/simklSyncService.js
@@ -3,6 +3,7 @@ import { ProfileManager } from "../../core/profile/profileManager.js";
 import { SimklAnimeIdPreference, TraktSettingsStore } from "../local/traktSettingsStore.js";
 import { SimklAuthService } from "./simklAuthService.js";
 import { simklRequest } from "./simklAuthService.js";
+import { shouldMarkCompletedSeriesWatched } from "./simklCompletedSeries.js";
 
 const STORE_KEY = "simklSyncState";
 const SNAPSHOT_SCHEMA_VERSION = 2;
@@ -505,12 +506,14 @@ function watchedProjection(snapshot) {
       return;
     }
     if (["hold", "dropped"].includes(entry.status)) return;
+    let hasEpisodeHistory = false;
     (entry.seasons || []).forEach((season) => {
       (season?.episodes || []).forEach((episode) => {
         if (!episode?.watched_at) return;
         const seasonNumber = Number(episode.tvdb?.season ?? season.number ?? 0);
         const episodeNumber = Number(episode.tvdb?.episode ?? episode.number ?? 0);
         if (episodeNumber <= 0) return;
+        hasEpisodeHistory = true;
         const watchedAt = parseDate(episode.watched_at, snapshot.lastSyncedAt);
         const watched = {
           ...base,
@@ -535,6 +538,13 @@ function watchedProjection(snapshot) {
         });
       });
     });
+    if (shouldMarkCompletedSeriesWatched(entry.status, hasEpisodeHistory)) {
+      const watchedAt = parseDate(
+        entry.last_watched_at || entry.added_to_watchlist_at,
+        snapshot.lastSyncedAt
+      );
+      items.push({ ...base, watchedAt });
+    }
   });
   return { items, historyItems, watchedShowSeedItems };
 }

--- a/js/data/repository/watchedSeriesReconciliationService.js
+++ b/js/data/repository/watchedSeriesReconciliationService.js
@@ -11,6 +11,15 @@ function isSeriesType(type = "") {
   return ["series", "tv", "anime", "show", "tvshow"].includes(normalized);
 }
 
+function isRemoteSimklSeriesMarker(item = {}, contentIds = new Set()) {
+  return (
+    String(item?.trackingProviderId || "").toLowerCase() === "simkl" &&
+    contentIds.has(String(item?.contentId || "")) &&
+    item?.season == null &&
+    item?.episode == null
+  );
+}
+
 function firstPositiveInt(values = []) {
   for (const value of values) {
     const numeric = Number(value);
@@ -202,6 +211,9 @@ export const watchedSeriesReconciliationService = {
       watchProgressRepository.getAll().catch(() => []),
       watchedItemsRepository.isWatched(normalizedContentId).catch(() => false)
     ]);
+    const hasRemoteSimklSeriesMarker = watchedItems.some((item) =>
+      isRemoteSimklSeriesMarker(item, contentIds)
+    );
 
     const watchedEpisodeKeys = new Set();
     watchedItems.forEach((item) => {
@@ -246,7 +258,11 @@ export const watchedSeriesReconciliationService = {
       return true;
     }
 
-    if (!allWatched && hasSeriesMarker) {
+    // A completed Simkl entry with no episode history is projected as a root
+    // watched marker, matching Android. It is provider state, not a local
+    // marker inferred from the episodes currently returned by the meta addon,
+    // so do not erase it merely because those episode rows are incomplete.
+    if (!allWatched && hasSeriesMarker && !hasRemoteSimklSeriesMarker) {
       await watchedItemsRepository.unmark(normalizedContentId, { rootOnly: true });
       detailWatchedEnrichmentService.invalidateCache(normalizedContentId);
       return true;


### PR DESCRIPTION
## Summary

A Simkl series that is marked completed but comes back with no per-episode watched history never showed as watched in the app. This happens with bulk marks and completions imported from another service. The web app only recorded per-episode watched items, so a completed series with no episode timestamps produced nothing, and episode reconciliation could not fix it later because there were no watched episodes to count. This ports the Android behavior, which adds a show level watched item for a completed series when there is no per-episode history.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

The Simkl watched projection walks each entry. For a series it only pushes a watched item per episode that has a `watched_at` timestamp. When Simkl returns a completed series with no per-episode timestamps, the series produced no watched items at all. `isWatched(seriesId)` needs a show level entry (season and episode both null) to report the whole series as watched, so the detail screen and home rows showed the series as unwatched. Reconciliation cannot recover it either, since it marks a series watched only when every released episode is covered, and here zero episodes are covered. The Android app handles this by emitting a show level watched item for a completed series when there is no episode history, and it has a unit test for it.

## Issue or approval

No linked issue. This matches the Android app, which has a unit test for it (`SimklProjectionsTest` "watched projection includes movie exact episodes and completed series marker").

## Reproduction steps

1. Connect a Simkl account.
2. Mark a series completed on Simkl without per-episode watched dates, or import a completed series from another service.
3. Sync and open the series in the app.
4. The series shows as unwatched even though Simkl has it completed.

## Old behavior

A completed series with no per-episode watched history produced no watched items, so the app never showed it as watched and reconciliation could not mark it later.

## New behavior

A completed series with no per-episode watched history gets a show level watched item, so the app shows it as watched, matching Android. A completed series that already has per-episode history is unchanged, since the per-episode items are enough and no extra marker is added.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the series branch of the Simkl watched projection changed. The movie branch, the per-episode handling, the playback progress path, and the storage shape are untouched. No UI changes.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test for the decision.

### Commands tested

```sh
npm run build
node --test js/data/repository/simklCompletedSeries.test.mjs
```

## Manual test flow

Ran the projection with a completed series that has no episode history and confirmed the watched items now include a show level entry with no season or episode, so `isWatched` reports the series as watched. Confirmed a completed series that already has per-episode history still produces only the per-episode items with no duplicate marker.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low. The extra item is added only for a completed series that produced no per-episode watched items, so it never duplicates existing episode history. If Simkl says a series is completed the user watched it, so marking it watched is correct.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
