### PR TITLE
Fix debrid resolution reading 4k from title text

### DIFF
--- a/js/core/debrid/directDebridStreamPresentation.js
+++ b/js/core/debrid/directDebridStreamPresentation.js
@@ -2,6 +2,7 @@ import { DebridSettingsStore } from "../../data/local/debridSettingsStore.js";
 import { DebridProviders } from "./debridProviders.js";
 import { DebridStreamTemplateEngine } from "./debridStreamTemplateEngine.js";
 import { sizeBytesFromStreamText } from "./streamTextSizeParser.js";
+import { resolutionFromFields } from "./streamResolution.js";
 
 const RESOLUTION_LABELS = {
   P2160: "2160p",
@@ -220,17 +221,6 @@ function searchText(stream = {}) {
     .toLowerCase();
 }
 
-function resolutionFromText(text = "") {
-  if (/\b(2160p?|4k|uhd)\b/i.test(text)) return "P2160";
-  if (/\b(1440p?|2k)\b/i.test(text)) return "P1440";
-  if (/\b(1080p?|fhd)\b/i.test(text)) return "P1080";
-  if (/\b(720p?|hd)\b/i.test(text)) return "P720";
-  if (/\b576p?\b/i.test(text)) return "P576";
-  if (/\b(480p?|sd)\b/i.test(text)) return "P480";
-  if (/\b360p?\b/i.test(text)) return "P360";
-  return "UNKNOWN";
-}
-
 function qualityFromText(text = "") {
   const value = String(text || "").toLowerCase();
   if (value.includes("remux")) return "BLURAY_REMUX";
@@ -403,9 +393,12 @@ function facts(stream = {}) {
   const resolve = stream.clientResolve || stream.raw?.clientResolve || {};
   const parsed = resolve.stream?.raw?.parsed || {};
   const text = searchText(stream);
-  const resolution = resolutionFromText(
-    [parsed.resolution, parsed.quality, stream.quality, text].filter(Boolean).join(" ")
-  );
+  const resolution = resolutionFromFields([
+    parsed.resolution,
+    parsed.quality,
+    stream.quality,
+    text
+  ]);
   const quality = qualityFromText([parsed.quality, text].filter(Boolean).join(" "));
   const visualTags = visualTagsFromText(parsed.hdr || [], text);
   const audioTags = audioTagsFromText(parsed.audio || [], text);

--- a/js/core/debrid/streamResolution.js
+++ b/js/core/debrid/streamResolution.js
@@ -1,0 +1,34 @@
+/**
+ * Classifies a debrid stream resolution from its metadata fields.
+ *
+ * The Android app checks the resolution fields in priority order (parsed
+ * resolution, then parsed quality, then the addon quality, then the free text)
+ * and takes the first field that yields a resolution. The web app instead
+ * joined every field into one string and took the highest token found anywhere,
+ * so a correctly parsed 1080p file whose title mentions a 4K remaster or a
+ * 2160p pack was classified as 4K. That wrong resolution then filtered and
+ * sorted the stream as 4K. `resolutionFromFields` restores the Android field
+ * priority so the parsed resolution wins over noise in the title.
+ */
+
+export function resolutionFromText(text = "") {
+  if (/\b(2160p?|4k|uhd)\b/i.test(text)) return "P2160";
+  if (/\b(1440p?|2k)\b/i.test(text)) return "P1440";
+  if (/\b(1080p?|fhd)\b/i.test(text)) return "P1080";
+  if (/\b(720p?|hd)\b/i.test(text)) return "P720";
+  if (/\b576p?\b/i.test(text)) return "P576";
+  if (/\b(480p?|sd)\b/i.test(text)) return "P480";
+  if (/\b360p?\b/i.test(text)) return "P360";
+  return "UNKNOWN";
+}
+
+export function resolutionFromFields(values = []) {
+  for (const value of values) {
+    if (!value) continue;
+    const resolution = resolutionFromText(value);
+    if (resolution !== "UNKNOWN") {
+      return resolution;
+    }
+  }
+  return "UNKNOWN";
+}

--- a/js/core/debrid/streamResolution.test.mjs
+++ b/js/core/debrid/streamResolution.test.mjs
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolutionFromText, resolutionFromFields } from "./streamResolution.js";
+
+test("field priority keeps the parsed resolution over noise in the title", () => {
+  // Parser is right: the file is 1080p. Title mentions a 4K remaster and a
+  // 2160p pack. Field priority must return 1080p, not 4K.
+  const result = resolutionFromFields([
+    "1080p",
+    "web-dl",
+    "",
+    "movie 2020 1080p web-dl x264 [4k remaster available] 2160p pack"
+  ]);
+  assert.equal(result, "P1080");
+});
+
+test("clean stream classifies the same as before", () => {
+  const result = resolutionFromFields(["2160p", "remux", "", "movie 2020 2160p uhd bluray remux"]);
+  assert.equal(result, "P2160");
+});
+
+test("falls through to the next field when a field has no resolution", () => {
+  const result = resolutionFromFields(["", "web-dl", "", "show s01e01 720p"]);
+  assert.equal(result, "P720");
+});
+
+test("uses the addon quality hint when nothing else has a resolution", () => {
+  const result = resolutionFromFields([null, "web-dl", "4k", "some release group"]);
+  assert.equal(result, "P2160");
+});
+
+test("returns UNKNOWN when no field carries a resolution", () => {
+  assert.equal(resolutionFromFields(["", "web-dl", "", "release group only"]), "UNKNOWN");
+});
+
+test("resolutionFromText still maps single tokens", () => {
+  assert.equal(resolutionFromText("1080p"), "P1080");
+  assert.equal(resolutionFromText("uhd"), "P2160");
+  assert.equal(resolutionFromText("nothing here"), "UNKNOWN");
+});


### PR DESCRIPTION
## Summary

A debrid stream that is really 1080p could be treated as 4K when its title or description mentioned a 4K remaster or a 2160p pack. The resolution picker joined every metadata field into one string and took the highest resolution token found anywhere, so noise in the title beat the correctly parsed resolution. That wrong resolution then filtered and sorted the stream as 4K. This ports the Android behavior, which checks the fields in priority order and takes the first one that has a resolution, so the parsed resolution wins.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

`facts()` built the resolution from `[parsed.resolution, parsed.quality, stream.quality, text]`. The web app joined all four with spaces and passed the whole string to `resolutionFromText`, which returns the highest token it can find. So a file with `parsed.resolution` of 1080p and a title like `1080p web-dl [4k remaster available] 2160p pack` came back as 2160p. The Android app resolves this differently: `streamResolution(parsed.resolution, parsed.quality, stream.quality, searchText)` uses `firstNotNullOfOrNull`, so it returns the resolution of the first field that has one. The parsed resolution is checked first, so the title noise never overrides it.

## Issue or approval

No linked issue. This matches the Android app resolution logic in `DirectDebridStreamFilter.streamResolution`.

## Reproduction steps

1. Open a title and load debrid streams.
2. Find a 1080p release whose title or description also mentions 4K or a 2160p pack.
3. Sort or filter by resolution.
4. The 1080p stream is treated as 4K, so it sorts and filters in the wrong bucket.

## Old behavior

The resolution was the highest token found across all fields joined together, so title noise could push a 1080p stream into the 4K bucket for filtering and sorting.

## New behavior

The resolution is taken from the first field that has one, in the order the Android app uses, so the parsed resolution wins over noise in the title. A stream whose fields all agree is classified exactly as before.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the resolution classification changed. The quality, visual tag, audio, channel, encode, language, release group, and size logic are untouched. The token matching itself is unchanged, since the same `resolutionFromText` is reused per field. No UI changes.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test for the resolution logic.

### Commands tested

```sh
npm run build
node --test js/core/debrid/streamResolution.test.mjs
```

## Manual test flow

Ran the resolution picker with a 1080p stream whose title mentions a 4K remaster and a 2160p pack, and confirmed it now returns 1080p instead of 4K. Confirmed a clean 4K stream still returns 4K, and that an addon quality hint of 4K is still used when no field has a parsed resolution.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low. A stream whose fields agree classifies exactly as before. The change only affects streams where a lower parsed resolution is followed by a higher token in the title or description, which is the case being fixed.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
