### PR TITLE
Load every catalog item in see all instead of skipping to 100

### DIFF
--- a/js/core/util/catalogPagination.js
+++ b/js/core/util/catalogPagination.js
@@ -1,0 +1,36 @@
+/**
+ * Merges a freshly fetched catalog page into the items already shown and
+ * computes the next skip offset for pagination.
+ *
+ * The next skip must advance by the number of items the addon actually
+ * returned, the way the Android app does in CatalogRow.mergeCatalogPage. The
+ * see all screen used to advance by a fixed 100, so a catalog whose addon
+ * returns a smaller page (many TMDB backed addons return about 20 items per
+ * page) had the see all view jump past everything between the real page size
+ * and 100, and those items never appeared. Advancing by the returned count
+ * keeps every item reachable. Duplicate ids are dropped so a repeated item is
+ * never shown twice, while the skip still advances past the whole returned
+ * page so the next request asks for fresh items.
+ *
+ * `displayItems` are the items to append (already filtered for display when
+ * needed) and `returnedCount` is the raw number of items the addon returned,
+ * which drives the skip so filtering never shrinks the step.
+ */
+
+export function mergeCatalogPage(existingItems, displayItems, currentSkip, returnedCount) {
+  const items = Array.isArray(existingItems) ? [...existingItems] : [];
+  const seen = new Set(items.map((item) => item?.id).filter(Boolean));
+  const incoming = Array.isArray(displayItems) ? displayItems : [];
+  let addedCount = 0;
+  incoming.forEach((item) => {
+    if (!item?.id || seen.has(item.id)) {
+      return;
+    }
+    seen.add(item.id);
+    items.push(item);
+    addedCount += 1;
+  });
+  const raw = Number.isFinite(returnedCount) ? returnedCount : incoming.length;
+  const nextSkip = Math.max(0, Number(currentSkip) || 0) + Math.max(0, raw);
+  return { items, addedCount, nextSkip, hasMore: raw > 0 };
+}

--- a/js/core/util/catalogPagination.test.mjs
+++ b/js/core/util/catalogPagination.test.mjs
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mergeCatalogPage } from "./catalogPagination.js";
+
+const items = (ids) => ids.map((id) => ({ id }));
+const ids = (start, end) => Array.from({ length: end - start }, (_, i) => `x${start + i}`);
+
+test("advances by the returned item count and keeps every item", () => {
+  const existing = items(ids(0, 11));
+  const incoming = items(ids(11, 28));
+  const merged = mergeCatalogPage(existing, incoming, 11);
+  assert.equal(merged.items.length, 28);
+  assert.equal(merged.addedCount, 17);
+  assert.equal(merged.nextSkip, 28);
+  assert.equal(merged.hasMore, true);
+});
+
+test("a duplicate page adds nothing but still advances past it", () => {
+  const existing = items(ids(0, 45));
+  const duplicate = items(ids(27, 45));
+  const merged = mergeCatalogPage(existing, duplicate, 45, 18);
+  assert.equal(merged.items.length, 45);
+  assert.equal(merged.addedCount, 0);
+  assert.equal(merged.nextSkip, 63);
+  assert.equal(merged.hasMore, true);
+});
+
+test("a small page advances by its real size, not a fixed 100", () => {
+  const merged = mergeCatalogPage(items(ids(0, 20)), items(ids(20, 40)), 20);
+  assert.equal(merged.nextSkip, 40);
+  assert.equal(merged.items.length, 40);
+});
+
+test("returnedCount drives the skip even when display items were filtered out", () => {
+  // Addon returned 20 items but only 5 survived the released filter.
+  const merged = mergeCatalogPage(items(ids(0, 20)), items(ids(20, 25)), 20, 20);
+  assert.equal(merged.nextSkip, 40);
+  assert.equal(merged.items.length, 25);
+});
+
+test("an empty page stops pagination and leaves the skip in place", () => {
+  const merged = mergeCatalogPage(items(ids(0, 20)), [], 20, 0);
+  assert.equal(merged.items.length, 20);
+  assert.equal(merged.nextSkip, 20);
+  assert.equal(merged.hasMore, false);
+});
+
+test("items without an id are skipped but still counted in the skip", () => {
+  const merged = mergeCatalogPage([{ id: "a" }], [{ id: null }, { id: "a" }, { id: "b" }], 1);
+  assert.deepEqual(
+    merged.items.map((item) => item.id),
+    ["a", "b"]
+  );
+  assert.equal(merged.addedCount, 1);
+  assert.equal(merged.nextSkip, 4);
+});

--- a/js/ui/screens/catalog/catalogSeeAllScreen.js
+++ b/js/ui/screens/catalog/catalogSeeAllScreen.js
@@ -6,6 +6,7 @@ import { Environment } from "../../../platform/environment.js";
 import { LayoutPreferences } from "../../../data/local/layoutPreferences.js";
 import { I18n } from "../../../i18n/index.js";
 import { filterReleasedItems } from "../../../core/util/releaseInfoUtils.js";
+import { mergeCatalogPage } from "../../../core/util/catalogPagination.js";
 import { focusWithoutAutoScroll } from "../../components/sidebarNavigation.js";
 import {
   posterItemFromNode,
@@ -189,7 +190,7 @@ export const CatalogSeeAllScreen = {
     this.items = this.layoutPrefs?.hideUnreleasedContent
       ? filterReleasedItems(initialItems)
       : [...initialItems];
-    this.nextSkip = this.items.length ? 100 : 0;
+    this.nextSkip = initialItems.length;
     this.loading = false;
     this.hasMore = true;
     this.lastFocusedKey = this.items[0]?.id ? `item:${this.items[0].id}` : null;
@@ -261,20 +262,11 @@ export const CatalogSeeAllScreen = {
     const incoming = this.layoutPrefs?.hideUnreleasedContent
       ? filterReleasedItems(rawIncoming)
       : rawIncoming;
-    let addedCount = 0;
-    if (rawIncoming.length) {
-      const seen = new Set(this.items.map((item) => item.id));
-      incoming.forEach((item) => {
-        if (!item?.id || seen.has(item.id)) {
-          return;
-        }
-        seen.add(item.id);
-        this.items.push(item);
-        addedCount += 1;
-      });
-      this.nextSkip = skip + 100;
-    }
-    this.hasMore = rawIncoming.length > 0;
+    const merged = mergeCatalogPage(this.items, incoming, skip, rawIncoming.length);
+    const addedCount = merged.addedCount;
+    this.items = merged.items;
+    this.nextSkip = merged.nextSkip;
+    this.hasMore = merged.hasMore;
     this.loading = false;
     this.pendingRestoreFocus = true;
     this.preserveViewportOnNextRender = Boolean(preserveViewport && addedCount > 0);


### PR DESCRIPTION
## Summary

The see all screen jumped its paging offset to 100 after the first page, so any catalog whose addon returns a smaller page lost everything between the real page size and 100. Many TMDB backed addons return about 20 items per page, so opening see all on those showed the first 20 items and then skipped straight to item 100, and items 20 through 99 never loaded. This makes the offset advance by the number of items the addon actually returned, the way the Android app does, so every item is reachable.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

On seed the screen set `this.nextSkip = this.items.length ? 100 : 0`, and after each page it set `this.nextSkip = skip + 100`. Both assume the addon returns 100 items per page. When an addon returns a smaller page, the next request asks for `skip=100` (or `skip=200`, and so on), so the items between the real page boundary and the fixed 100 are never requested. The Android app advances the skip by the size of the page it just received in `CatalogRow.mergeCatalogPage`, and its `CatalogRowPaginationTest` locks in that behavior (merge a page at skip 11 and the next skip is the new total, not a fixed step). This ports that: the skip advances by the number of items the addon returned, so a 20 item page moves the skip by 20 and the next page continues from there.

## Issue or approval

No linked issue. This matches the Android app paging logic in `CatalogRow.mergeCatalogPage`, which is covered by `CatalogRowPaginationTest`.

## Reproduction steps

1. Open a catalog whose addon returns fewer than 100 items per page (most TMDB backed catalogs return about 20).
2. Open the see all view for that catalog.
3. Scroll past the first page.
4. The list shows the first page and then stops, because the next request skips ahead to item 100 and the items in between are never loaded.

## Old behavior

The paging offset was seeded to 100 and then increased by 100 each page, regardless of how many items the addon actually returned, so smaller pages left a gap of missing items that never loaded.

## New behavior

The paging offset advances by the number of items the addon returned, so every item loads in order no matter the addon page size. Duplicate ids are still dropped so a repeated item is never shown twice, and the offset still advances past the whole returned page so the next request asks for fresh items.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the see all paging offset changed. The merge keeps the same dedup by id that the screen already used, and the released content filter still runs exactly as before. The offset now advances by the raw returned count so filtering out unreleased items never shrinks the step. No UI changes.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test for the paging logic.

### Commands tested

```sh
npm run build
node --test js/core/util/catalogPagination.test.mjs
```

## Manual test flow

Simulated a 60 item catalog served by an addon that returns 20 items per page. With the old fixed 100 step the see all view showed 20 items and lost 40. With the fix it loads all 60 in order. Confirmed a duplicate page adds nothing but still advances the offset, and that an empty page stops paging.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low. For an addon that really does return 100 items per page the offset advances by 100 as before. The seed uses the real first page size, so at worst a smaller first page triggers one harmless deduped refetch rather than skipping items. The dedup and the released filter are unchanged.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
