### PR TITLE
Fix dismissed Next Up card never returning after new episodes

### DIFF
--- a/js/data/local/continueWatchingPreferences.dismissKey.test.mjs
+++ b/js/data/local/continueWatchingPreferences.dismissKey.test.mjs
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Mirrors Android TraktSettingsDataStore.addDismissedNextUpKey /
+// removeDismissedNextUpKeysForContent, whose dismiss key is the bare contentId
+// (nextUpDismissKey returns contentId.trim()). The removal must clear both the
+// bare key ("contentId") and any legacy "contentId|season|episode" entry, the
+// same as Android's filterNot { it == trimmed || it.startsWith("$trimmed|") }.
+
+const store = new Map();
+
+globalThis.localStorage = {
+  getItem: (k) => (store.has(k) ? store.get(k) : null),
+  setItem: (k, v) => store.set(k, String(v)),
+  removeItem: (k) => store.delete(k),
+  clear: () => store.clear()
+};
+
+const { ContinueWatchingPreferences } = await import("./continueWatchingPreferences.js");
+
+function reset() {
+  store.clear();
+}
+
+test("removing dismissed keys clears the bare contentId that dismiss stores", () => {
+  reset();
+  // Home screen stores the bare contentId when a Next Up card is dismissed.
+  ContinueWatchingPreferences.addDismissedNextUpKey("tt123");
+  assert.deepEqual(ContinueWatchingPreferences.getDismissedNextUpKeys(), ["tt123"]);
+
+  // Watching a new episode saves progress, which must remove the dismiss.
+  ContinueWatchingPreferences.removeDismissedNextUpKeysForContent("tt123");
+  assert.deepEqual(ContinueWatchingPreferences.getDismissedNextUpKeys(), []);
+});
+
+test("removing dismissed keys also clears the legacy contentId|season|episode form", () => {
+  reset();
+  ContinueWatchingPreferences.replaceDismissedNextUpKeys(["tt123|1|2", "tt123"]);
+  ContinueWatchingPreferences.removeDismissedNextUpKeysForContent("tt123");
+  assert.deepEqual(ContinueWatchingPreferences.getDismissedNextUpKeys(), []);
+});
+
+test("removing dismissed keys leaves other content untouched", () => {
+  reset();
+  ContinueWatchingPreferences.replaceDismissedNextUpKeys(["tt123", "tt999", "tt999|3|4"]);
+  ContinueWatchingPreferences.removeDismissedNextUpKeysForContent("tt123");
+  assert.deepEqual(ContinueWatchingPreferences.getDismissedNextUpKeys(), ["tt999", "tt999|3|4"]);
+});

--- a/js/data/local/continueWatchingPreferences.js
+++ b/js/data/local/continueWatchingPreferences.js
@@ -84,7 +84,7 @@ export const ContinueWatchingPreferences = {
     return writeForProfile(profileId, {
       ...current,
       dismissedNextUpKeys: current.dismissedNextUpKeys.filter(
-        (key) => !key.startsWith(`${normalizedContentId}|`)
+        (key) => key !== normalizedContentId && !key.startsWith(`${normalizedContentId}|`)
       )
     });
   }


### PR DESCRIPTION
## Summary

Dismissing a Next Up card hid that show forever. Once you dismissed it, the show never came back to Continue Watching or Next Up even after you watched a new episode. This makes watching new progress clear the dismiss, the way the Android app does.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

When a Next Up card is dismissed the home screen stores the bare content id (for example `tt123`). When you then watch a new episode, `saveProgress` calls `removeDismissedNextUpKeysForContent` to clear that dismiss so the show can return. But the remove only dropped keys that start with `${contentId}|`, so it never matched the bare id that was actually stored. The dismiss stayed forever and the show never reappeared.

The Android app stores the same bare content id (`nextUpDismissKey` returns `contentId.trim()`) and its `removeDismissedNextUpKeysForContent` clears both forms with `filterNot { it == trimmed || it.startsWith("$trimmed|") }`. The web was missing the exact match half. This adds it.

## Issue or approval

No linked issue. This matches the Android app, where `TraktSettingsDataStore.removeDismissedNextUpKeysForContent` removes both the bare content id and the legacy `contentId|season|episode` form.

## Reproduction steps

1. Have a series in Continue Watching with a Next Up card.
2. Dismiss the Next Up card.
3. Watch a new episode of that series so progress is saved.
4. The series never returns to Continue Watching or Next Up, even though there is fresh progress.

## Old behavior

The dismiss was stored as the bare content id, but the removal only looked for keys shaped like `contentId|season|episode`, so it never cleared the stored key. The show stayed dismissed permanently.

## New behavior

Saving new progress clears the dismiss for that content, so the show returns to Continue Watching and Next Up. Both the bare content id and the legacy `contentId|season|episode` form are cleared, matching Android.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the removal filter in `removeDismissedNextUpKeysForContent` changed, by one condition. The add path, the read path, and the suppression logic are untouched.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test for the dismiss key logic.

### Commands tested

```sh
npm run build
node --test js/data/local/continueWatchingPreferences.dismissKey.test.mjs
```

## Manual test flow

Dismissed a Next Up card, then saved new progress for the same series. Before the fix the show stayed gone. After the fix it returned. Confirmed the legacy `contentId|season|episode` form is still cleared and that other content is left untouched.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low. The change only adds one more thing the remove clears (the bare content id that the app already stores). Nothing else that was cleared before stops being cleared.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
