### PR TITLE
Do not show badges from disabled badge filters

### DIFF
--- a/js/core/streams/streamBadgeRules.disabledFilter.test.mjs
+++ b/js/core/streams/streamBadgeRules.disabledFilter.test.mjs
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { matchStreamBadges } from "./streamBadgeRules.js";
+
+// Mirrors Android StreamBadgeRulesTest "matches active badge filters against
+// stream metadata": a disabled filter (isEnabled = false) must not produce a
+// badge even when its pattern matches, and an inactive import is skipped
+// entirely. Android's StreamBadgeMatcher.compile drops filters where
+// !filter.isEnabled.
+
+const stream = {
+  name: "Some Release DV Atmos Movie 2160p"
+};
+
+test("disabled badge filter does not produce a badge", () => {
+  const rules = {
+    imports: [
+      {
+        sourceUrl: "inactive",
+        isActive: false,
+        filters: [{ name: "Inactive", pattern: "Movie" }]
+      },
+      {
+        sourceUrl: "active",
+        isActive: true,
+        filters: [
+          { name: "Dolby Vision", pattern: "DV" },
+          { name: "Atmos", pattern: "Atmos" },
+          { name: "Disabled", pattern: "Movie", isEnabled: false }
+        ]
+      }
+    ]
+  };
+
+  const badges = matchStreamBadges(stream, rules);
+  assert.deepEqual(
+    badges.map((badge) => badge.name),
+    ["Dolby Vision", "Atmos"]
+  );
+});
+
+test("enabled filters still match", () => {
+  const rules = {
+    imports: [
+      {
+        sourceUrl: "active",
+        isActive: true,
+        filters: [
+          { name: "Dolby Vision", pattern: "DV" },
+          { name: "Movie", pattern: "Movie", isEnabled: true }
+        ]
+      }
+    ]
+  };
+
+  const badges = matchStreamBadges(stream, rules);
+  assert.deepEqual(
+    badges.map((badge) => badge.name),
+    ["Dolby Vision", "Movie"]
+  );
+});

--- a/js/core/streams/streamBadgeRules.js
+++ b/js/core/streams/streamBadgeRules.js
@@ -289,6 +289,7 @@ function compileStreamBadgeFilters(rules = {}) {
     .filter((importItem) => importItem.isActive)
     .flatMap((importItem) =>
       importItem.filters
+        .filter((filter) => filter.isEnabled !== false)
         .map((filter) => {
           try {
             const pattern = String(filter.pattern || "").trim();


### PR DESCRIPTION
## Summary

A badge filter that was turned off still showed its badge on matching streams. This makes disabled badge filters produce no badge, the way the Android app does.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

When badge rules are compiled, the web mapped every filter in the active import into a live regex. It never checked the filter's `isEnabled` flag, so a filter the user turned off (or one imported with `"isEnabled": false`) still matched and rendered its badge on every stream it hit.

The Android app skips disabled filters when it compiles. `StreamBadgeMatcher.compile` drops any filter where `!filter.isEnabled`, and `StreamBadgeRulesTest` locks this in: an import with an enabled Dolby Vision filter, an enabled Atmos filter, and a disabled filter whose pattern matches the stream produces exactly `["Dolby Vision", "Atmos"]`. This adds the same `isEnabled` check to the web compile step.

## Issue or approval

No linked issue. This matches the Android app, where `StreamBadgeMatcher.compile` skips filters with `isEnabled` false, covered by `StreamBadgeRulesTest`.

## Reproduction steps

1. Import a badge set, or add badge filters.
2. Turn one badge filter off (or import JSON with `"isEnabled": false` for one filter).
3. Open a stream list where that filter's pattern matches.
4. The disabled badge still shows on matching streams.

## Old behavior

Disabled badge filters were compiled and matched just like enabled ones, so turning a badge off had no effect and it kept appearing.

## New behavior

Disabled badge filters are skipped at compile time, so they never produce a badge. Enabled filters match exactly as before.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the compile step in `compileStreamBadgeFilters` changed, by adding one filter for `isEnabled`. Blank name and blank pattern filters were already dropped in normalize, so nothing else needed to change. The matcher, the presentation, and the import parsing are untouched.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test for the badge compile logic.

### Commands tested

```sh
npm run build
node --test js/core/streams/streamBadgeRules.disabledFilter.test.mjs
```

## Manual test flow

Built badge rules with an enabled Dolby Vision filter, an enabled Atmos filter, and a disabled filter whose pattern matched the stream. Before the fix the disabled badge appeared. After the fix only the two enabled badges appear. Confirmed enabled filters still match.

## Screenshots / Video

Not a UI change beyond the badge no longer showing.

## Logs

Not applicable.

## Regression risk

Low. The only change is that filters marked disabled are no longer compiled. Enabled filters, which are the default, behave exactly as before.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
