### PR TITLE
Warn before Simkl removals that clear watch history or a rating

### DIFF
--- a/js/data/repository/simklSyncService.js
+++ b/js/data/repository/simklSyncService.js
@@ -275,6 +275,30 @@ function statusDefinitionForEntry(entry) {
   return STATUS_DEFINITIONS.find((definition) => definition.status === entry?.status) || null;
 }
 
+// Mirrors Android SimklLibraryEntry.destructiveRemovalImpacts: removing a Simkl
+// entry clears watched history when it is in any status other than plan to
+// watch, or carries watch data, and clears a rating when a rating value or
+// rating timestamp is present.
+export function destructiveRemovalImpacts(entry) {
+  const impacts = [];
+  if (!entry) return impacts;
+  if (
+    entry.status !== "plantowatch" ||
+    entry.last_watched_at ||
+    entry.last_watched ||
+    Number(entry.watched_episodes_count) > 0 ||
+    (entry.seasons || []).some((season) =>
+      (season.episodes || []).some((episode) => episode.watched_at)
+    )
+  ) {
+    impacts.push("watched_history");
+  }
+  if (entry.user_rating != null || entry.user_rated_at) {
+    impacts.push("rating");
+  }
+  return impacts;
+}
+
 function toLibraryEntry(entry, snapshot) {
   const media = mediaForEntry(entry);
   const definition = statusDefinitionForEntry(entry);
@@ -643,14 +667,7 @@ export const SimklSyncService = {
       throw new Error("Completed is managed by watched history");
     }
     if (!destination) {
-      const hasHistory = Boolean(
-        entry &&
-        (entry.last_watched_at ||
-          entry.user_rating != null ||
-          (entry.seasons || []).some((season) =>
-            (season.episodes || []).some((episode) => episode.watched_at)
-          ))
-      );
+      const hasHistory = destructiveRemovalImpacts(entry).length > 0;
       if (hasHistory && !destructiveRemovalConfirmed) {
         const error = new Error(
           "Removing this Simkl status would also clear watched history or a rating"

--- a/js/data/repository/simklSyncService.removalImpacts.test.mjs
+++ b/js/data/repository/simklSyncService.removalImpacts.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { destructiveRemovalImpacts } from "./simklSyncService.js";
+
+// Mirrors Android SimklLibraryRemovalPolicyTest. Removing a Simkl entry must
+// warn when it would clear watched history or a rating. The Simkl status values
+// on web are the raw api strings ("plantowatch", "watching", "completed", ...).
+
+test("plain plan to watch removal is safe", () => {
+  assert.deepEqual(destructiveRemovalImpacts({ status: "plantowatch" }), []);
+});
+
+test("watched status removal requires history confirmation", () => {
+  assert.deepEqual(destructiveRemovalImpacts({ status: "watching" }), ["watched_history"]);
+});
+
+test("watch counters protect plan to watch history", () => {
+  assert.deepEqual(
+    destructiveRemovalImpacts({ status: "plantowatch", watched_episodes_count: 2 }),
+    ["watched_history"]
+  );
+});
+
+test("rating timestamp is protected when numeric rating is absent", () => {
+  assert.deepEqual(
+    destructiveRemovalImpacts({ status: "plantowatch", user_rated_at: "2026-07-23T10:00:00Z" }),
+    ["rating"]
+  );
+});
+
+test("history and rating impacts are combined", () => {
+  assert.deepEqual(destructiveRemovalImpacts({ status: "completed", user_rating: 9 }), [
+    "watched_history",
+    "rating"
+  ]);
+});
+
+test("episode watch timestamps protect a plan to watch entry", () => {
+  const entry = {
+    status: "plantowatch",
+    seasons: [{ episodes: [{ watched_at: "2026-07-01T00:00:00Z" }] }]
+  };
+  assert.deepEqual(destructiveRemovalImpacts(entry), ["watched_history"]);
+});
+
+test("a missing entry has no impacts", () => {
+  assert.deepEqual(destructiveRemovalImpacts(null), []);
+});


### PR DESCRIPTION
## Summary

Removing a Simkl item could silently wipe watched history or a rating without asking. The warning only fired for a few cases, so removing a show you were watching, or an item you had rated, went through with no confirmation. This makes the warning cover the same cases the Android app does.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

The web already asks the user to confirm before a Simkl removal that would clear history or a rating, but the check that decides when to ask was too narrow. It only looked at `last_watched_at`, a numeric `user_rating`, and per episode `watched_at`. So these removals went through with no warning and lost data:

- An item in any status other than plan to watch (watching, on hold, dropped, completed) with no `last_watched_at` yet.
- A plan to watch item that already has `watched_episodes_count` above zero.
- An item that has a rating timestamp (`user_rated_at`) but no numeric rating.

The Android app decides this in `SimklLibraryEntry.destructiveRemovalImpacts`, which flags watched history when the status is anything other than plan to watch, or the entry carries any watch data, and flags a rating when either a rating value or a rating timestamp is present. `SimklLibraryRemovalPolicyTest` locks in each of these cases. This ports that same logic to the web check.

## Issue or approval

No linked issue. This matches the Android app, where `SimklLibraryEntry.destructiveRemovalImpacts` is covered by `SimklLibraryRemovalPolicyTest`.

## Reproduction steps

1. Connect Simkl.
2. Put a show in Watching (or rate an item without leaving a numeric score).
3. Remove it from the library.
4. It is removed with no confirmation, and the watched history or rating is gone.

## Old behavior

The removal warning only fired when the entry had a `last_watched_at`, a numeric `user_rating`, or an episode with a `watched_at`. Other entries that still held history or a rating were removed silently.

## New behavior

The warning also fires for any status other than plan to watch, for a positive `watched_episodes_count`, and for a rating timestamp with no numeric score, matching Android. A plain plan to watch item with no watch data and no rating still removes without a prompt, so nothing extra is asked when there is nothing to lose.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the history check inside `applyMembershipChanges` changed. The logic is pulled into a small `destructiveRemovalImpacts` helper that mirrors Android, and the removal path calls it instead of the old inline check. The existing confirmation flow in the UI is untouched, and the confirmed removal path is unchanged.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test for the removal impact logic.

### Commands tested

```sh
npm run build
node --test js/data/repository/simklSyncService.removalImpacts.test.mjs
```

## Manual test flow

Checked each case against the ported helper: plain plan to watch is safe, a watching status warns, a plan to watch item with watched episodes warns, a rating timestamp with no numeric score warns, and a completed item with a rating reports both history and rating. Confirmed the old inline check missed the first four, which is the silent data loss this fixes.

## Screenshots / Video

Not a UI change. The existing confirmation dialog now appears in more cases.

## Logs

Not applicable.

## Regression risk

Low. The change only widens when the existing confirmation is shown, so at worst the user is asked to confirm a removal that would clear history or a rating. A plain plan to watch item with nothing to lose still removes without a prompt. The only callers are the three UI list pickers, which already handle the confirmation.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
