### PR TITLE
Hide series only tracking statuses for movies

### DIFF
--- a/js/core/tracking/trackingLibraryMembership.js
+++ b/js/core/tracking/trackingLibraryMembership.js
@@ -1,0 +1,18 @@
+const SERIES_CONTENT_TYPES = ["tv", "show", "anime"];
+
+export function supportsMembershipFor(tab, contentType) {
+  if (!tab || tab.isMembershipDestination === false) {
+    return false;
+  }
+  const supported = tab.supportedContentTypes;
+  if (!Array.isArray(supported)) {
+    return true;
+  }
+  const normalized = String(contentType || "").toLowerCase();
+  return supported.some((entry) => {
+    const value = String(entry || "").toLowerCase();
+    return (
+      value === normalized || (value === "series" && SERIES_CONTENT_TYPES.includes(normalized))
+    );
+  });
+}

--- a/js/core/tracking/trackingLibraryMembership.supportsFor.test.mjs
+++ b/js/core/tracking/trackingLibraryMembership.supportsFor.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { supportsMembershipFor } from "./trackingLibraryMembership.js";
+
+// Mirrors TrackingLibraryMembershipTest tab setup: watching is series only,
+// planned accepts movie and series, completed is not a membership destination.
+const watching = {
+  key: "watching",
+  supportedContentTypes: ["series"],
+  isMembershipDestination: true
+};
+const planned = {
+  key: "planned",
+  supportedContentTypes: ["movie", "series"],
+  isMembershipDestination: true
+};
+const completed = {
+  key: "completed",
+  supportedContentTypes: ["movie", "series"],
+  isMembershipDestination: false
+};
+
+test("movie cannot select a series only status", () => {
+  assert.equal(supportsMembershipFor(watching, "movie"), false);
+});
+
+test("movie can select a status that accepts movies", () => {
+  assert.equal(supportsMembershipFor(planned, "movie"), true);
+});
+
+test("series can select a series only status", () => {
+  assert.equal(supportsMembershipFor(watching, "series"), true);
+});
+
+test("series aliases match a series status", () => {
+  for (const type of ["tv", "show", "anime"]) {
+    assert.equal(supportsMembershipFor(watching, type), true);
+  }
+});
+
+test("read only status is never a destination", () => {
+  assert.equal(supportsMembershipFor(completed, "movie"), false);
+  assert.equal(supportsMembershipFor(completed, "series"), false);
+});
+
+test("tab without declared content types accepts anything", () => {
+  const anyTab = { key: "watchlist", isMembershipDestination: true };
+  assert.equal(supportsMembershipFor(anyTab, "movie"), true);
+  assert.equal(supportsMembershipFor(anyTab, "series"), true);
+});

--- a/js/ui/components/posterOptionsMenu.js
+++ b/js/ui/components/posterOptionsMenu.js
@@ -4,6 +4,7 @@ import { libraryRepository, LibrarySourceMode } from "../../data/repository/libr
 import { watchedItemsRepository } from "../../data/repository/watchedItemsRepository.js";
 import { watchProgressRepository } from "../../data/repository/watchProgressRepository.js";
 import { watchedSeriesReconciliationService } from "../../data/repository/watchedSeriesReconciliationService.js";
+import { supportsMembershipFor } from "../../core/tracking/trackingLibraryMembership.js";
 import { NuvioDialog } from "./nuvioDialog.js";
 
 function t(key, params = {}, fallback = key) {
@@ -188,9 +189,10 @@ export async function createPosterListPickerState(state) {
     return null;
   }
   const tabs = await libraryRepository.getListTabs().catch(() => []);
+  const contentType = item.type || "movie";
   const resolvedTabs =
     Array.isArray(tabs) && tabs.length
-      ? tabs.filter((tab) => tab.isMembershipDestination !== false)
+      ? tabs.filter((tab) => supportsMembershipFor(tab, contentType))
       : [{ key: "local", title: t("detail.library", {}, "Library"), type: "local" }];
   const libraryItem = toLibraryItem(item);
   const snapshot = await libraryRepository

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -32,6 +32,7 @@ import {
   TraktAuthService
 } from "../../../data/repository/traktAuthService.js";
 import { toTraktImageUrl } from "../../../core/trakt/traktImageUrl.js";
+import { supportsMembershipFor } from "../../../core/tracking/trackingLibraryMembership.js";
 import { Environment } from "../../../platform/environment.js";
 import { Platform } from "../../../platform/index.js";
 import { getTvRuntimePerformanceProfile } from "../../../platform/tvRuntimePerformance.js";
@@ -4810,7 +4811,7 @@ export const MetaDetailsScreen = {
     const tabs = await libraryRepository.getListTabs().catch(() => []);
     const resolvedTabs =
       Array.isArray(tabs) && tabs.length
-        ? tabs.filter((tab) => tab.isMembershipDestination !== false)
+        ? tabs.filter((tab) => supportsMembershipFor(tab, item.itemType))
         : [{ key: "local", title: t("detail.library", {}, "Library"), type: "local" }];
     const snapshot = await libraryRepository
       .getMembershipSnapshot(item)

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -24,6 +24,7 @@ import { HomeCatalogStore } from "../../../data/local/homeCatalogStore.js";
 import { CollectionsStore, buildCollectionHomeKey } from "../../../data/local/collectionsStore.js";
 import { TmdbService } from "../../../core/tmdb/tmdbService.js";
 import { TmdbMetadataService } from "../../../core/tmdb/tmdbMetadataService.js";
+import { supportsMembershipFor } from "../../../core/tracking/trackingLibraryMembership.js";
 import { TmdbSettingsStore } from "../../../data/local/tmdbSettingsStore.js";
 import { metaRepository } from "../../../data/repository/metaRepository.js";
 import { mdbListRepository } from "../../../data/repository/mdbListRepository.js";
@@ -4990,9 +4991,10 @@ export const HomeScreen = {
       return false;
     }
     const tabs = await libraryRepository.getListTabs().catch(() => []);
+    const contentType = item.type || "movie";
     const resolvedTabs =
       Array.isArray(tabs) && tabs.length
-        ? tabs.filter((tab) => tab.isMembershipDestination !== false)
+        ? tabs.filter((tab) => supportsMembershipFor(tab, contentType))
         : [{ key: "local", title: t("detail.library", {}, "Library"), type: "local" }];
     const libraryItem = {
       itemId: item.id,


### PR DESCRIPTION
## Summary

The library list picker offered series only statuses for movies. A movie could be added to Simkl statuses like Watching or On Hold, which only apply to shows. This filters the statuses by content type the same way the Android app does.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

The three list picker dialogs (poster options, detail screen, home hold menu) built the status list by filtering tabs only on `isMembershipDestination`. They never checked the tab's supported content types, so a movie was shown every enabled status, including Watching and On Hold, which Simkl only defines for shows.

The Android app filters the same tabs with `tab.supportsMembershipFor(contentType)` in all three list picker dialogs (`PosterOptionsDialog`, `MetaDetailsScreen`, `HomeScreen`). That helper checks `isMembershipDestination` and then the tab's supported content types, with the usual series alias for tv, show, and anime. `TrackingLibraryMembershipTest` locks this in with "movie cannot select a series only status". This ports the same helper to the web and uses it at the three matching call sites.

## Issue or approval

No linked issue. This matches the Android app, where `LibraryListTab.supportsMembershipFor` gates the status list by content type and is covered by `TrackingLibraryMembershipTest`.

## Reproduction steps

1. Connect Simkl.
2. Open the list picker for a movie (poster hold menu, detail screen, or home).
3. The status list shows Watching and On Hold, which only apply to shows.

## Old behavior

Movies were offered series only statuses (Watching, On Hold). Selecting one set a status that does not apply to movies on Simkl.

## New behavior

Movies only see statuses that accept movies (Plan to Watch, Dropped). Shows see every status as before. Tabs without declared content types, such as Trakt lists, still show for any content type.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Adds one small helper, `supportsMembershipFor`, that mirrors the Android function, and swaps the three identical tab filters to use it. The status definitions, the toggle flow, and the save path are untouched. The local library fallback tab is unchanged.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test for the content type helper.

### Commands tested

```sh
npm run build
node --test js/core/tracking/trackingLibraryMembership.supportsFor.test.mjs
```

## Manual test flow

Built the Simkl status tabs and filtered them for a movie and for a show. Before the fix a movie saw Watching and On Hold. After the fix a movie sees only Plan to Watch and Dropped, a show sees every status, and a Trakt style tab with no declared content types still shows for any type.

## Screenshots / Video

Not a UI change beyond the status list no longer offering series only statuses for movies.

## Logs

Not applicable.

## Regression risk

Low. The change only narrows which statuses a movie is offered, matching Android. Shows are unaffected, and tabs without declared content types still show for any content type.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
