### PR TITLE
Send a Trakt stop scrobble when playback pauses

### DIFF
--- a/js/data/repository/traktScrobbleService.js
+++ b/js/data/repository/traktScrobbleService.js
@@ -148,7 +148,7 @@ export const TraktScrobbleService = {
   pause(context) {
     clearStartTimer();
     if (lastAction === "start" || lastAction === null) {
-      void sendScrobbleRequest("pause", context);
+      void sendScrobbleRequest("stop", context);
     }
   },
 

--- a/js/data/repository/traktScrobbleService.pauseStop.test.mjs
+++ b/js/data/repository/traktScrobbleService.pauseStop.test.mjs
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Repository imports touch LocalStore during module init, so give them a
+// localStorage before importing the service under test.
+globalThis.localStorage = (() => {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear()
+  };
+})();
+
+const { TraktScrobbleService } = await import("./traktScrobbleService.js");
+const { TraktAuthService } = await import("./traktAuthService.js");
+
+// Mirrors TraktTrackingScrobblerTest "pause preserves trakt stop behavior":
+// a pause sends a Trakt stop scrobble, never a pause scrobble.
+function withStubbedTrakt(run) {
+  const originalFetch = globalThis.fetch;
+  const originalToken = TraktAuthService.getValidAccessToken;
+  const calls = [];
+  globalThis.fetch = async (url) => {
+    calls.push(String(url));
+    return { ok: true, status: 200, text: async () => "" };
+  };
+  TraktAuthService.getValidAccessToken = async () => "test-token";
+  return Promise.resolve(run(calls)).finally(() => {
+    globalThis.fetch = originalFetch;
+    TraktAuthService.getValidAccessToken = originalToken;
+  });
+}
+
+const movieContext = {
+  contentType: "movie",
+  title: "The Shawshank Redemption",
+  imdbId: "tt0111161",
+  progressPercent: 45
+};
+
+test("pause sends a trakt stop scrobble", async () => {
+  await withStubbedTrakt(async (calls) => {
+    TraktScrobbleService.pause(movieContext);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const paths = calls.map((url) => url.replace(/^.*\/scrobble\//, "scrobble/"));
+    assert.ok(
+      paths.some((path) => path === "scrobble/stop"),
+      `expected a stop scrobble, got ${JSON.stringify(paths)}`
+    );
+    assert.ok(
+      !paths.some((path) => path === "scrobble/pause"),
+      `expected no pause scrobble, got ${JSON.stringify(paths)}`
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Pausing a Trakt tracked video sent a pause scrobble to Trakt. Trakt then kept the item as still watching and did not record the stop. The Android app sends a stop scrobble when playback pauses. This makes the web do the same.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

On pause the web called `/scrobble/pause`. Trakt treats a pause scrobble as playback that is still going, so the item stays in the currently watching list and the watched progress is not committed.

The Android app maps a pause event to a stop scrobble. `TraktTrackingScrobbler` sends `service.scrobbleStop(...)` for both `PAUSE` and `STOP`, and never calls `scrobblePause`. `TraktTrackingScrobblerTest` locks this in with "pause preserves trakt stop behavior", which asserts a stop request goes out and no pause request does. This changes the web pause path to send a stop scrobble to match.

## Issue or approval

No linked issue. This matches the Android app, where `TraktTrackingScrobbler` maps a pause to `scrobbleStop` and is covered by `TraktTrackingScrobblerTest`.

## Reproduction steps

1. Connect Trakt.
2. Play a movie or episode, then pause it.
3. Trakt receives a pause scrobble, so the item stays as watching and the stop is not recorded.

## Old behavior

Pausing sent `/scrobble/pause`, so Trakt kept the item as still watching and did not record a stop.

## New behavior

Pausing sends `/scrobble/stop`, so Trakt records the stop and, when progress is high enough, marks the item watched, the same as Android. Resuming still sends a start scrobble as before.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the Trakt pause path changed, from a pause scrobble to a stop scrobble. The start path, the stop path, the payload builders, and the Simkl scrobbler are untouched. The existing guard that avoids repeating the action is kept.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test that stubs the Trakt network call and checks which scrobble endpoint is hit.

### Commands tested

```sh
npm run build
node --test js/data/repository/traktScrobbleService.pauseStop.test.mjs
```

## Manual test flow

Stubbed the Trakt token and fetch, then called the pause handler for a movie at 45 percent. Before the fix the request went to `/scrobble/pause`. After the fix it goes to `/scrobble/stop` and never to `/scrobble/pause`, matching the Android test.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low. The change only swaps the action sent on pause, from pause to stop, matching Android. The start and stop paths are unchanged, and the guard still prevents repeating the action while paused.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
