### PR TITLE
Drop stale Simkl playback for completed series

### DIFF
--- a/js/data/repository/simklCompletedPlayback.test.mjs
+++ b/js/data/repository/simklCompletedPlayback.test.mjs
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Repository imports touch LocalStore during module init, so give them a
+// localStorage before importing the service under test.
+globalThis.localStorage = (() => {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear()
+  };
+})();
+
+const { LocalStore } = await import("../../core/storage/localStore.js");
+const { SimklSyncService } = await import("./simklSyncService.js");
+
+// Keep getProgressSnapshot from touching the network.
+SimklSyncService.refresh = async () => false;
+
+const showMedia = {
+  title: "Show",
+  year: 2016,
+  runtime: 24,
+  ids: { simkl: 39687, imdb: "tt4574334" }
+};
+
+function seedSnapshot({ completedAt, pausedAt }) {
+  const snapshot = {
+    schemaVersion: 2,
+    initialized: true,
+    entries: [
+      {
+        mediaType: "shows",
+        status: "completed",
+        last_watched_at: completedAt,
+        show: showMedia
+      }
+    ],
+    playback: [
+      {
+        id: 1,
+        show: showMedia,
+        episode: { season: 1, number: 5 },
+        progress: 40,
+        paused_at: pausedAt
+      }
+    ],
+    lastSyncedAt: Date.now(),
+    lastCheckedAt: Date.now()
+  };
+  LocalStore.set("simklSyncState", { version: 1, profiles: { 1: snapshot } });
+}
+
+// Mirrors SimklPlaybackReconciliationTest
+// "newer completed series summary discards stale episode playback".
+test("completed series summary discards stale episode playback", async () => {
+  seedSnapshot({ completedAt: "2024-04-30T22:14:00Z", pausedAt: "2024-04-30T22:13:00Z" });
+  const { playbackItems } = await SimklSyncService.getProgressSnapshot();
+  assert.equal(playbackItems.length, 0, "stale playback should be dropped for a completed series");
+});
+
+// Mirrors SimklPlaybackReconciliationTest
+// "newer episode playback remains after completed series summary".
+test("newer playback remains after a completed series summary", async () => {
+  seedSnapshot({ completedAt: "2024-04-30T22:13:00Z", pausedAt: "2024-04-30T22:14:00Z" });
+  const { playbackItems } = await SimklSyncService.getProgressSnapshot();
+  assert.equal(playbackItems.length, 1, "a newer rewatch pause should be kept");
+});

--- a/js/data/repository/simklSyncService.js
+++ b/js/data/repository/simklSyncService.js
@@ -546,6 +546,12 @@ function reconciledPlaybackProgress(snapshot, watchedItems) {
     .filter((progress) => {
       const entry = findEntry(snapshot, progress);
       if (["hold", "dropped"].includes(entry?.status)) return false;
+      if (entry?.status === "completed") {
+        const completedAt = parseDate(entry.last_watched_at, NaN);
+        if (Number.isFinite(completedAt) && completedAt >= Number(progress.updatedAt || 0)) {
+          return false;
+        }
+      }
       return !watchedItems.some(
         (watched) =>
           String(watched.contentId || "").toLowerCase() ===


### PR DESCRIPTION
## Summary

A Simkl series that is marked completed but has no per episode history kept a stale paused episode in Continue Watching. The Android app drops that playback once the completion time is newer than the paused time. This makes the web do the same.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

When a series is imported or marked completed at the summary level, Simkl returns the entry with a `last_watched_at` but no season or episode `watched_at` timestamps. The web only hid playback for hold or dropped entries, or when a matching per episode watched item superseded it. With no episode history there was no watched item, so the old paused episode stayed in Continue Watching.

The Android app handles this in `SimklPlaybackReconciliation.hidesPlayback`, which hides playback for a completed entry when the completion time is at or after the paused time. `SimklPlaybackReconciliationTest` locks it with "newer completed series summary discards stale episode playback" and "newer episode playback remains after completed series summary". This adds the same completed branch to the web reconciliation.

## Issue or approval

No linked issue. This matches the Android app, where `SimklPlaybackReconciliation` hides completed series playback and is covered by `SimklPlaybackReconciliationTest`.

## Reproduction steps

1. Connect Simkl.
2. Have a series marked completed with no per episode history and a leftover paused episode.
3. Open Continue Watching. The old paused episode still shows.

## Old behavior

The paused episode of a completed series stayed in Continue Watching.

## New behavior

The paused episode is dropped when the completion time is at or after the paused time, the same as Android. A newer pause after completion is kept as a rewatch.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the completed branch was added to `reconciledPlaybackProgress`. The hold and dropped path, the per episode watched supersession, the projections, and the mutation bodies are untouched.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test that seeds a completed series snapshot and checks the reconciled playback.

### Commands tested

```sh
npm run build
node --test js/data/repository/simklCompletedPlayback.test.mjs
```

## Manual test flow

Seeded a completed series with a paused episode and no episode history. Before the fix the paused episode stayed in the reconciled playback. After the fix it is dropped when the completion time is at or after the paused time, and a newer pause is kept. This mirrors the two Android tests.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low. The change only adds a completed series check that hides playback when the completion time is at or after the paused time. Hold, dropped, and the per episode watched path are unchanged, and a newer rewatch pause is still kept.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
