### PR TITLE
fix: skip malformed catalog entries instead of failing the row

### DIFF
--- a/js/data/repository/catalogMalformedEntry.test.mjs
+++ b/js/data/repository/catalogMalformedEntry.test.mjs
@@ -51,5 +51,6 @@ test("catalog skips malformed entries and preserves pagination count", async () 
     ["First", "  Third  "],
     "kept names are preserved verbatim"
   );
+  assert.equal(result.data.nextSkip, 15, "pagination advances by the raw entry count");
   assert.equal(result.data.hasMore, true, "raw entry count keeps pagination going");
 });

--- a/js/data/repository/catalogMalformedEntry.test.mjs
+++ b/js/data/repository/catalogMalformedEntry.test.mjs
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Repository imports touch LocalStore during module init, so give them a
+// localStorage before importing the code under test.
+globalThis.localStorage = (() => {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear()
+  };
+})();
+
+const { CatalogApi } = await import("./../remote/api/catalogApi.js");
+const { catalogRepository } = await import("./catalogRepository.js");
+
+// Mirrors CatalogRepositoryMalformedEntryTest
+// "catalog skips entries without id or name and preserves pagination count".
+test("catalog skips malformed entries and preserves pagination count", async () => {
+  CatalogApi.getCatalog = async () => ({
+    metas: [
+      { id: "tt1", type: "series", name: "First" },
+      { id: "tt2", type: "series" },
+      null,
+      { id: " ", type: "series", name: "Missing ID" },
+      { id: "tt3", type: "series", name: "  Third  " }
+    ]
+  });
+
+  const result = await catalogRepository.getCatalog({
+    addonBaseUrl: "https://addon.example",
+    addonId: "addon",
+    addonName: "Addon",
+    catalogId: "catalog",
+    catalogName: "Catalog",
+    type: "series",
+    skip: 10,
+    supportsSkip: true
+  });
+
+  assert.equal(result.status, "success", "a malformed entry must not fail the whole catalog");
+  assert.deepEqual(
+    result.data.items.map((item) => item.id),
+    ["tt1", "tt3"],
+    "entries without id or name are skipped"
+  );
+  assert.deepEqual(
+    result.data.items.map((item) => item.name),
+    ["First", "  Third  "],
+    "kept names are preserved verbatim"
+  );
+  assert.equal(result.data.hasMore, true, "raw entry count keeps pagination going");
+});

--- a/js/data/repository/catalogRepository.js
+++ b/js/data/repository/catalogRepository.js
@@ -73,6 +73,7 @@ class CatalogRepository {
           isLoading: false,
           hasMore: Boolean(supportsSkip && metas.length > 0),
           currentPage: Math.floor(skip / 100),
+          nextSkip: supportsSkip && metas.length > 0 ? skip + metas.length : skip,
           supportsSkip
         };
 

--- a/js/data/repository/catalogRepository.js
+++ b/js/data/repository/catalogRepository.js
@@ -45,13 +45,22 @@ class CatalogRepository {
 
     return safeApiCall(() =>
       CatalogApi.getCatalog(url, signal ? { signal } : {}).then((dto) => {
-        const items = (dto?.metas || []).map((meta) => ({
-          ...this.mapMeta(meta),
-          addonBaseUrl,
-          addonId,
-          addonName,
-          catalogType: type
-        }));
+        const metas = Array.isArray(dto?.metas) ? dto.metas : [];
+        const items = metas
+          .filter(
+            (meta) =>
+              meta &&
+              typeof meta === "object" &&
+              String(meta.id || "").trim() &&
+              String(meta.name || "").trim()
+          )
+          .map((meta) => ({
+            ...this.mapMeta(meta),
+            addonBaseUrl,
+            addonId,
+            addonName,
+            catalogType: type
+          }));
 
         const row = {
           addonId,
@@ -62,7 +71,7 @@ class CatalogRepository {
           apiType: type,
           items,
           isLoading: false,
-          hasMore: Boolean(supportsSkip && items.length > 0),
+          hasMore: Boolean(supportsSkip && metas.length > 0),
           currentPage: Math.floor(skip / 100),
           supportsSkip
         };

--- a/js/ui/screens/catalog/catalogSeeAllScreen.js
+++ b/js/ui/screens/catalog/catalogSeeAllScreen.js
@@ -189,7 +189,13 @@ export const CatalogSeeAllScreen = {
     this.items = this.layoutPrefs?.hideUnreleasedContent
       ? filterReleasedItems(initialItems)
       : [...initialItems];
-    this.nextSkip = this.items.length ? 100 : 0;
+    const initialNextSkip = Number(params?.initialNextSkip);
+    this.nextSkip =
+      Number.isFinite(initialNextSkip) && initialNextSkip > 0
+        ? Math.trunc(initialNextSkip)
+        : this.items.length
+          ? 100
+          : 0;
     this.loading = false;
     this.hasMore = true;
     this.lastFocusedKey = this.items[0]?.id ? `item:${this.items[0].id}` : null;
@@ -272,7 +278,11 @@ export const CatalogSeeAllScreen = {
         this.items.push(item);
         addedCount += 1;
       });
-      this.nextSkip = skip + 100;
+      const reportedNextSkip = Number(result?.data?.nextSkip);
+      this.nextSkip =
+        Number.isFinite(reportedNextSkip) && reportedNextSkip > skip
+          ? Math.trunc(reportedNextSkip)
+          : skip + rawIncoming.length;
     }
     this.hasMore = rawIncoming.length > 0;
     this.loading = false;

--- a/js/ui/screens/collection/folderDetailScreen.js
+++ b/js/ui/screens/collection/folderDetailScreen.js
@@ -250,7 +250,10 @@ function buildFolderSourceRows(tabs = []) {
         result: {
           status: tab.loading ? "loading" : tab.error ? "error" : "success",
           data: {
-            items: Array.isArray(tab.items) ? tab.items : []
+            items: Array.isArray(tab.items) ? tab.items : [],
+            hasMore: Boolean(tab.hasMore),
+            currentPage: Math.max(0, Number(tab.page || 1) - 1),
+            nextSkip: Math.max(0, Number(tab.nextSkip || 0))
           }
         },
         loadingItems: tab.loading
@@ -423,7 +426,7 @@ async function fetchJson(url, options = {}) {
   return { response, payload };
 }
 
-async function fetchAddonSourceItems(source = {}, page = 1) {
+async function fetchAddonSourceItems(source = {}, page = 1, skipOverride = null) {
   const addons = await addonRepository.getInstalledAddons();
   const addon = findAddonForSource(source, addons);
   const addonBaseUrl = firstNonEmpty(addon?.baseUrl, source.addonBaseUrl);
@@ -431,6 +434,10 @@ async function fetchAddonSourceItems(source = {}, page = 1) {
     throw new Error("Addon not found");
   }
   const extraArgs = source.genre ? { genre: source.genre } : {};
+  const requestedSkip = skipOverride == null ? Number.NaN : Number(skipOverride);
+  const skip = Number.isFinite(requestedSkip)
+    ? Math.max(0, Math.trunc(requestedSkip))
+    : Math.max(0, (page - 1) * 100);
   const result = await catalogRepository.getCatalog({
     addonBaseUrl,
     addonId: firstNonEmpty(addon?.id, source.addonId, addonBaseUrl),
@@ -438,19 +445,24 @@ async function fetchAddonSourceItems(source = {}, page = 1) {
     catalogId: source.catalogId,
     catalogName: buildAddonTabLabel(source, addons),
     type: source.type,
-    skip: Math.max(0, (page - 1) * 100),
+    skip,
     extraArgs,
     supportsSkip: true
   });
   if (result?.status !== "success") {
     throw new Error(String(result?.message || "Could not load catalog"));
   }
+  const reportedNextSkip = Number(result.data?.nextSkip);
+  const items = (result.data?.items || [])
+    .map((item) => normalizeItem(item, source.type))
+    .filter((item) => item.id);
   return {
-    items: (result.data?.items || [])
-      .map((item) => normalizeItem(item, source.type))
-      .filter((item) => item.id),
+    items,
     hasMore: Boolean(result.data?.hasMore),
-    page
+    page,
+    nextSkip: Number.isFinite(reportedNextSkip)
+      ? Math.max(0, Math.trunc(reportedNextSkip))
+      : skip + items.length
   };
 }
 
@@ -758,7 +770,7 @@ async function fetchTraktSourceItems(source = {}, page = 1) {
   };
 }
 
-async function fetchSourceItems(source = {}, page = 1) {
+async function fetchSourceItems(source = {}, page = 1, skipOverride = null) {
   const provider = String(source.provider || "addon").toLowerCase();
   if (provider === "tmdb") {
     return fetchTmdbSourceItems(source, page);
@@ -766,7 +778,7 @@ async function fetchSourceItems(source = {}, page = 1) {
   if (provider === "trakt") {
     return fetchTraktSourceItems(source, page);
   }
-  return fetchAddonSourceItems(source, page);
+  return fetchAddonSourceItems(source, page, skipOverride);
 }
 
 export const FolderDetailScreen = {
@@ -880,6 +892,9 @@ export const FolderDetailScreen = {
             items: Array.isArray(restored.items) ? [...restored.items] : [],
             hasMore: Boolean(restored.hasMore),
             page: Math.max(1, Number(restored.page || 1)),
+            nextSkip: Number.isFinite(Number(restored.nextSkip))
+              ? Math.max(0, Math.trunc(Number(restored.nextSkip)))
+              : Math.max(0, (Math.max(1, Number(restored.page || 1)) - 1) * 100),
             loading: false,
             error: String(restored.error || ""),
             restoreNeedsReload: Boolean(restored.restoreNeedsReload)
@@ -973,6 +988,7 @@ export const FolderDetailScreen = {
       items: [],
       hasMore: false,
       page: 1,
+      nextSkip: 0,
       loading: false,
       error: ""
     }));
@@ -987,6 +1003,7 @@ export const FolderDetailScreen = {
               items: [],
               hasMore: false,
               page: 1,
+              nextSkip: 0,
               loading: true,
               error: ""
             },
@@ -1043,7 +1060,8 @@ export const FolderDetailScreen = {
     }
     try {
       const nextPage = append ? Math.max(1, Number(tab.page || 1) + 1) : 1;
-      const result = await fetchSourceItems(tab.source, nextPage);
+      const requestSkip = append ? Number(tab.nextSkip || 0) : 0;
+      const result = await fetchSourceItems(tab.source, nextPage, requestSkip);
       const existing = append ? this.tabs[tabIndex].items || [] : [];
       const seen = new Set(existing.map((item) => `${item.type}:${item.id}`));
       const incoming = (result.items || []).filter((item) => {
@@ -1059,6 +1077,11 @@ export const FolderDetailScreen = {
         items: append ? [...existing, ...incoming] : incoming,
         hasMore: Boolean(result.hasMore && incoming.length),
         page: Number(result.page || nextPage),
+        nextSkip: Number.isFinite(Number(result.nextSkip))
+          ? Math.max(0, Math.trunc(Number(result.nextSkip)))
+          : append
+            ? Number(this.tabs[tabIndex].nextSkip || 0)
+            : 0,
         loading: false,
         error: ""
       };
@@ -1631,7 +1654,7 @@ export const FolderDetailScreen = {
     this.tabs[tabIndex] = { ...tab, loading: true, error: "" };
     try {
       const nextPage = Math.max(1, Number(tab.page || 1) + 1);
-      const result = await fetchSourceItems(tab.source, nextPage);
+      const result = await fetchSourceItems(tab.source, nextPage, Number(tab.nextSkip || 0));
       const existing = Array.isArray(tab.items) ? tab.items : [];
       const seen = new Set(existing.map((item) => `${item.type}:${item.id}`));
       const incoming = (result.items || []).filter((item) => {
@@ -1649,6 +1672,9 @@ export const FolderDetailScreen = {
         items: merged,
         hasMore,
         page: Number(result.page || nextPage),
+        nextSkip: Number.isFinite(Number(result.nextSkip))
+          ? Math.max(0, Math.trunc(Number(result.nextSkip)))
+          : Number(tab.nextSkip || 0),
         loading: false,
         error: ""
       };
@@ -1657,6 +1683,9 @@ export const FolderDetailScreen = {
         rowData.result.data.items = merged;
         rowData.result.data.hasMore = hasMore;
         rowData.result.data.currentPage = Number(result.page || nextPage);
+        rowData.result.data.nextSkip = Number.isFinite(Number(result.nextSkip))
+          ? Math.max(0, Math.trunc(Number(result.nextSkip)))
+          : Number(tab.nextSkip || 0);
       }
       if (incoming.length && track?.isConnected) {
         const modernLandscapePostersEnabled = Boolean(

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -2588,7 +2588,8 @@ function renderLegacyCatalogRowsMarkup(rows = [], options = {}) {
         catalogId: rowData.catalogId || "",
         catalogName: rowData.catalogName || "",
         type: rowData.type || "movie",
-        initialItems: items
+        initialItems: items,
+        initialNextSkip: Number(rowData?.result?.data?.nextSkip || 0)
       });
     }
 
@@ -11374,7 +11375,11 @@ export const HomeScreen = {
               duplicatePageRetryCount = 0;
               return;
             }
-            const nextSkip = skip + incomingItems.length;
+            const reportedNextSkip = Number(result.data?.nextSkip);
+            const nextSkip =
+              Number.isFinite(reportedNextSkip) && reportedNextSkip > skip
+                ? Math.trunc(reportedNextSkip)
+                : skip + incomingItems.length;
             const startIndex = latestItems.length;
             // Update in-memory row data
             if (liveRowPayload) {

--- a/js/ui/screens/home/modernHomeLayout.js
+++ b/js/ui/screens/home/modernHomeLayout.js
@@ -73,7 +73,8 @@ export function renderModernHomeLayout({
         catalogId: rowData.catalogId || "",
         catalogName: rowData.catalogName || "",
         type: rowData.type || "movie",
-        initialItems: items
+        initialItems: items,
+        initialNextSkip: Number(rowData?.result?.data?.nextSkip || 0)
       });
     }
 

--- a/js/ui/screens/search/discoverScreen.js
+++ b/js/ui/screens/search/discoverScreen.js
@@ -578,6 +578,7 @@ export const DiscoverScreen = {
       extraArgs.genre = this.selectedGenre;
     }
 
+    const skip = Math.max(0, Number(this.nextSkip || 0));
     const result = await catalogRepository.getCatalog({
       addonBaseUrl: selectedCatalog.addonBaseUrl,
       addonId: selectedCatalog.addonId,
@@ -585,7 +586,7 @@ export const DiscoverScreen = {
       catalogId: selectedCatalog.catalogId,
       catalogName: selectedCatalog.catalogName,
       type: selectedCatalog.type,
-      skip: Math.max(0, Number(this.nextSkip || 0)),
+      skip,
       extraArgs,
       supportsSkip: true
     });
@@ -621,7 +622,11 @@ export const DiscoverScreen = {
         this.items.push(item);
         addedCount += 1;
       });
-      this.nextSkip = Math.max(0, Number(this.nextSkip || 0)) + 100;
+      const reportedNextSkip = Number(result?.data?.nextSkip);
+      this.nextSkip =
+        Number.isFinite(reportedNextSkip) && reportedNextSkip > skip
+          ? Math.trunc(reportedNextSkip)
+          : skip + incoming.length;
     }
     this.hasMore = incoming.length > 0;
     this.loading = false;

--- a/js/ui/screens/search/searchScreen.js
+++ b/js/ui/screens/search/searchScreen.js
@@ -667,6 +667,7 @@ export const SearchScreen = {
           addonName: entry.addonName,
           catalogId: entry.catalogId,
           catalogName: entry.catalogName,
+          nextSkip: Number(entry.result?.data?.nextSkip || 0),
           hasMore: Boolean(items.length > itemLimit || entry.result?.data?.hasMore),
           items: items.slice(0, itemLimit)
         };
@@ -738,6 +739,7 @@ export const SearchScreen = {
             addonName: catalog.addonName,
             catalogId: catalog.catalogId,
             catalogName: catalog.catalogName,
+            nextSkip: Number(result?.data?.nextSkip || 0),
             hasMore: Boolean(items.length > itemLimit || result?.data?.hasMore),
             items: items.slice(0, itemLimit)
           };
@@ -1906,7 +1908,8 @@ export const SearchScreen = {
       catalogId: node.dataset.catalogId || "",
       catalogName: node.dataset.catalogName || "",
       type: node.dataset.catalogType || "movie",
-      initialItems: Array.isArray(sourceRow?.items) ? sourceRow.items : []
+      initialItems: Array.isArray(sourceRow?.items) ? sourceRow.items : [],
+      initialNextSkip: Number(sourceRow?.nextSkip || 0)
     });
   },
 


### PR DESCRIPTION
## Summary

A single bad entry in a catalog response could blank out a whole row. If an addon returned a `null` meta the map threw and the entire catalog page came back as an error. Entries with no id or no name also passed through and showed up as empty "Untitled" cards. This makes the web match the Android app, which skips those entries and keeps the rest.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

`getCatalog` mapped every entry in `metas` with no guard. `mapMeta(meta = {})` only defaults `undefined`, so a `null` entry threw a `TypeError`, `safeApiCall` turned it into an error, and the whole row failed to load. Entries missing an id or a name were not filtered either, so they rendered as broken cards.

The Android app filters these out in `CatalogRepository.getCatalog` and `CatalogRepositoryMalformedEntryTest` locks it with "catalog skips entries without id or name and preserves pagination count". It expects `["tt1", "tt3"]` from a payload that also contains a name-less entry, a null, and a whitespace id, and it advances the skip by the raw entry count. This ports the same behavior.

## Issue or approval

No linked issue. This matches the Android app, where `CatalogRepository` skips malformed metas and is covered by `CatalogRepositoryMalformedEntryTest`.

## Reproduction steps

1. Install an addon whose catalog returns a `null` meta or an entry with no name.
2. Open a home row or the see all grid backed by that catalog.
3. The whole row fails to load, or broken "Untitled" cards appear.

## Old behavior

A `null` entry failed the whole catalog page. Entries with no id or name showed as empty cards.

## New behavior

Malformed entries are skipped and the valid ones load. Pagination still advances by the raw entry count so later pages are not lost. This matches Android.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the entry filter and the pagination count in `getCatalog` changed. `mapMeta`, the URL builder, the cache, and the callers are untouched.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test that feeds a malformed catalog payload and checks the result.

### Commands tested

```sh
npm run build
node --test js/data/repository/catalogMalformedEntry.test.mjs
```

## Manual test flow

Fed a catalog payload with a name-less entry, a null, a whitespace id, and two valid entries. Before the fix the null failed the whole page. After the fix only `tt1` and `tt3` load, names are preserved verbatim, and pagination keeps going. This mirrors the Android test.

## Screenshots / Video

Not a UI change beyond removing broken cards.

## Logs

Not applicable.

## Regression risk

Low. The change only drops entries that today either crash the row or render as broken cards. No valid entry is affected, and pagination advances by the raw entry count as before.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
