### PR TITLE
fix: hide series only Simkl statuses for movies

### DIFF
--- a/js/core/util/libraryMembership.js
+++ b/js/core/util/libraryMembership.js
@@ -1,0 +1,21 @@
+// Whether a library status destination accepts the given content type.
+// Mirrors the Android LibraryListTab.supportsMembershipFor check so a movie is
+// not offered a series only status such as Watching or On Hold. A tab with no
+// declared content types accepts anything, and "series" also covers tv, show
+// and anime items.
+const SERIES_ALIASES = ["tv", "show", "anime"];
+
+export function tabSupportsContentType(tab, contentType) {
+  if (!tab || tab.isMembershipDestination === false) {
+    return false;
+  }
+  const supported = tab.supportedContentTypes;
+  if (supported == null) {
+    return true;
+  }
+  const type = String(contentType || "").toLowerCase();
+  return supported.some((value) => {
+    const normalized = String(value).toLowerCase();
+    return normalized === type || (normalized === "series" && SERIES_ALIASES.includes(type));
+  });
+}

--- a/js/core/util/libraryMembership.test.mjs
+++ b/js/core/util/libraryMembership.test.mjs
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Repository imports touch LocalStore during module init, so give them a
+// localStorage before importing the service under test.
+globalThis.localStorage = (() => {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+    clear: () => store.clear()
+  };
+})();
+
+const { tabSupportsContentType } = await import("./libraryMembership.js");
+const { SimklSyncService } = await import("../../data/repository/simklSyncService.js");
+
+// Keep getLibraryTabs from touching the network.
+SimklSyncService.refresh = async () => false;
+
+const tabs = await SimklSyncService.getLibraryTabs();
+const keysFor = (type) => tabs.filter((tab) => tabSupportsContentType(tab, type)).map((tab) => tab.key);
+
+// Shows the old destination only filter offered a series only status to a movie.
+test("old destination only filter offered a series only status to a movie", () => {
+  const offered = tabs
+    .filter((tab) => tab.isMembershipDestination !== false)
+    .map((tab) => tab.key);
+  assert.ok(
+    offered.includes("simkl:status:watching"),
+    "reproduces the bug: Watching was offered for a movie"
+  );
+});
+
+// Mirrors TrackingLibraryMembershipTest "movie cannot select a series only status".
+test("a movie is not offered series only statuses", () => {
+  const offered = keysFor("movie");
+  assert.ok(!offered.includes("simkl:status:watching"), "Watching is series only");
+  assert.ok(!offered.includes("simkl:status:hold"), "On Hold is series only");
+  assert.ok(offered.includes("simkl:status:plantowatch"), "Plan to Watch stays for a movie");
+  assert.ok(offered.includes("simkl:status:dropped"), "Dropped stays for a movie");
+});
+
+// A series keeps every writable status.
+test("a series keeps series statuses", () => {
+  const offered = keysFor("series");
+  assert.ok(offered.includes("simkl:status:watching"), "Watching stays for a series");
+  assert.ok(offered.includes("simkl:status:hold"), "On Hold stays for a series");
+});
+
+// Mirrors TrackingLibraryMembershipTest "read only provider status cannot be selected".
+test("a read only status is never offered", () => {
+  assert.ok(!keysFor("movie").includes("simkl:status:completed"), "Completed is read only");
+  assert.ok(!keysFor("series").includes("simkl:status:completed"), "Completed is read only");
+});
+
+// tv, show and anime items are treated as series.
+test("tv and anime are treated as series", () => {
+  assert.ok(keysFor("tv").includes("simkl:status:watching"), "tv counts as series");
+  assert.ok(keysFor("anime").includes("simkl:status:hold"), "anime counts as series");
+});
+
+// A tab with no declared content types accepts anything.
+test("a tab without content types accepts anything", () => {
+  const localTab = { key: "local", isMembershipDestination: true };
+  assert.equal(tabSupportsContentType(localTab, "movie"), true);
+});

--- a/js/ui/components/posterOptionsMenu.js
+++ b/js/ui/components/posterOptionsMenu.js
@@ -4,6 +4,7 @@ import { libraryRepository, LibrarySourceMode } from "../../data/repository/libr
 import { watchedItemsRepository } from "../../data/repository/watchedItemsRepository.js";
 import { watchProgressRepository } from "../../data/repository/watchProgressRepository.js";
 import { watchedSeriesReconciliationService } from "../../data/repository/watchedSeriesReconciliationService.js";
+import { tabSupportsContentType } from "../../core/util/libraryMembership.js";
 import { NuvioDialog } from "./nuvioDialog.js";
 
 function t(key, params = {}, fallback = key) {
@@ -190,7 +191,7 @@ export async function createPosterListPickerState(state) {
   const tabs = await libraryRepository.getListTabs().catch(() => []);
   const resolvedTabs =
     Array.isArray(tabs) && tabs.length
-      ? tabs.filter((tab) => tab.isMembershipDestination !== false)
+      ? tabs.filter((tab) => tabSupportsContentType(tab, item.type))
       : [{ key: "local", title: t("detail.library", {}, "Library"), type: "local" }];
   const libraryItem = toLibraryItem(item);
   const snapshot = await libraryRepository

--- a/js/ui/screens/detail/metaDetailsScreen.js
+++ b/js/ui/screens/detail/metaDetailsScreen.js
@@ -13,6 +13,7 @@ import { watchedSeriesReconciliationService } from "../../../data/repository/wat
 import { TmdbService } from "../../../core/tmdb/tmdbService.js";
 import { TmdbMetadataService } from "../../../core/tmdb/tmdbMetadataService.js";
 import { normalizeTmdbBackdropUrl } from "../../../core/tmdb/tmdbImageUrl.js";
+import { tabSupportsContentType } from "../../../core/util/libraryMembership.js";
 import { LayoutPreferences } from "../../../data/local/layoutPreferences.js";
 import {
   showHomeRatings,
@@ -4810,7 +4811,7 @@ export const MetaDetailsScreen = {
     const tabs = await libraryRepository.getListTabs().catch(() => []);
     const resolvedTabs =
       Array.isArray(tabs) && tabs.length
-        ? tabs.filter((tab) => tab.isMembershipDestination !== false)
+        ? tabs.filter((tab) => tabSupportsContentType(tab, item.itemType))
         : [{ key: "local", title: t("detail.library", {}, "Library"), type: "local" }];
     const snapshot = await libraryRepository
       .getMembershipSnapshot(item)

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -19,6 +19,7 @@ import { mapWithConcurrency } from "../../../core/network/mapWithConcurrency.js"
 import { filterReleasedItems } from "../../../core/util/releaseInfoUtils.js";
 import { LayoutPreferences } from "../../../data/local/layoutPreferences.js";
 import { showHomeRatings } from "../../../core/util/imdbRatingVisibility.js";
+import { tabSupportsContentType } from "../../../core/util/libraryMembership.js";
 import { ContinueWatchingPreferences } from "../../../data/local/continueWatchingPreferences.js";
 import { HomeCatalogStore } from "../../../data/local/homeCatalogStore.js";
 import { CollectionsStore, buildCollectionHomeKey } from "../../../data/local/collectionsStore.js";
@@ -4992,7 +4993,7 @@ export const HomeScreen = {
     const tabs = await libraryRepository.getListTabs().catch(() => []);
     const resolvedTabs =
       Array.isArray(tabs) && tabs.length
-        ? tabs.filter((tab) => tab.isMembershipDestination !== false)
+        ? tabs.filter((tab) => tabSupportsContentType(tab, item.type))
         : [{ key: "local", title: t("detail.library", {}, "Library"), type: "local" }];
     const libraryItem = {
       itemId: item.id,


### PR DESCRIPTION
## Summary

The Simkl list picker offered "Watching" and "On Hold" for movies. Those statuses are for series only, so picking one sent a movie to a status Simkl does not use and left the movie stuck in that status locally. The Android app hides statuses that do not fit the item type. This makes the web do the same.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

The library status picker filtered tabs only by whether they were a writable destination. It never checked the item type, so a movie was shown the series only "Watching" and "On Hold" statuses. Selecting one calls `/sync/add-to-list` with the movie under a status Simkl only uses for series, and the local entry is set to that status too, which never round trips back from Simkl.

The Simkl status definitions already carry the allowed content types (`watching` and `hold` are `["series"]`). Android gates this in `LibraryListTab.supportsMembershipFor` and `TrackingLibraryMembershipTest` locks it with "movie cannot select a series only status" and "read only provider status cannot be selected". This adds the same content type check to the three places the web builds the status list.

## Issue or approval

No linked issue. This matches the Android app, where `supportsMembershipFor` gates status selection by content type and is covered by `TrackingLibraryMembershipTest`.

## Reproduction steps

1. Connect Simkl and set the library source to Simkl.
2. Open the list picker on a movie, from the home poster menu or the detail screen.
3. "Watching" and "On Hold" appear even though they are series only.

## Old behavior

Movies were offered the series only "Watching" and "On Hold" statuses.

## New behavior

Movies only see statuses that fit a movie (Plan to Watch, Dropped). Series still see every status. The read only "Completed" status stays hidden as before. This matches Android.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the three status list filters now call a shared `tabSupportsContentType` helper. The toggle, save, apply, and snapshot paths are untouched, and tabs with no declared content types still accept anything.

## Testing

### Devices / platforms tested

Chrome on macOS, plus a Node unit test built from the real Simkl status tabs.

### Commands tested

```sh
npm run build
node --test js/core/util/libraryMembership.test.mjs
```

## Manual test flow

Built the real Simkl status tabs and checked the picker. Before the fix a movie was offered "Watching". After the fix a movie only sees Plan to Watch and Dropped, a series still sees Watching and On Hold, and Completed stays hidden. This mirrors the Android test.

## Screenshots / Video

Removes two statuses that should not appear for movies.

## Logs

Not applicable.

## Regression risk

Low. The filter only removes statuses that do not fit the item type. Series behavior is unchanged, tabs with no declared content types still pass, and the read only status stays hidden as before.

## Breaking changes

None.

## Linked issues

No linked issue. Android parity fix.
