### PR TITLE
fix: show poster art for poster style continue watching cards

### DIFF
--- a/js/core/util/continueWatchingImage.js
+++ b/js/core/util/continueWatchingImage.js
@@ -1,0 +1,32 @@
+// Continue Watching card artwork selection, ported from the Android app.
+//
+// Poster style shows a portrait poster, so it must ignore the episode thumbnail
+// setting and prefer the poster then the backdrop, never the landscape episode
+// still. This mirrors continueWatchingUsesEpisodeThumbnails and
+// continueWatchingImageModel (preferPosterArtwork) on Android.
+
+export function continueWatchingUsesEpisodeThumbnails(cardStyle, useEpisodeThumbnails) {
+  return useEpisodeThumbnails !== false && String(cardStyle || "card") !== "poster";
+}
+
+export function continueWatchingImageSources(art = {}, options = {}) {
+  const { poster, backdrop, thumbnail, episodeThumbnail, background } = art;
+  const isNextUp = Boolean(options.isNextUp);
+  const hasAired = options.hasAired !== false;
+
+  if (String(options.cardStyle || "card") === "poster") {
+    return [poster, backdrop, background];
+  }
+
+  if (continueWatchingUsesEpisodeThumbnails(options.cardStyle, options.useEpisodeThumbnails)) {
+    if (!isNextUp) {
+      return [episodeThumbnail, backdrop, poster, thumbnail, background];
+    }
+    if (!hasAired) {
+      return [backdrop, poster, thumbnail, background, episodeThumbnail];
+    }
+    return [thumbnail, episodeThumbnail, backdrop, poster, background];
+  }
+
+  return [backdrop, poster, thumbnail, episodeThumbnail, background];
+}

--- a/js/core/util/continueWatchingImage.js
+++ b/js/core/util/continueWatchingImage.js
@@ -1,32 +1,45 @@
 // Continue Watching card artwork selection, ported from the Android app.
-//
-// Poster style shows a portrait poster, so it must ignore the episode thumbnail
-// setting and prefer the poster then the backdrop, never the landscape episode
-// still. This mirrors continueWatchingUsesEpisodeThumbnails and
-// continueWatchingImageModel (preferPosterArtwork) on Android.
+
+function normalizeCardStyle(cardStyle) {
+  const normalized = String(cardStyle || "card")
+    .trim()
+    .toLowerCase();
+  return ["card", "wide", "poster"].includes(normalized) ? normalized : "card";
+}
 
 export function continueWatchingUsesEpisodeThumbnails(cardStyle, useEpisodeThumbnails) {
-  return useEpisodeThumbnails !== false && String(cardStyle || "card") !== "poster";
+  return useEpisodeThumbnails !== false && normalizeCardStyle(cardStyle) !== "poster";
 }
 
 export function continueWatchingImageSources(art = {}, options = {}) {
-  const { poster, backdrop, thumbnail, episodeThumbnail, background } = art;
+  const { poster, backdrop, thumbnail, episodeThumbnail } = art;
+  const cardStyle = normalizeCardStyle(options.cardStyle);
+  const useEpisodeThumbnails = continueWatchingUsesEpisodeThumbnails(
+    cardStyle,
+    options.useEpisodeThumbnails
+  );
+  // Wide cards use a poster-shaped strip on Android, so they share the poster-art
+  // resolution path while still honoring the episode-thumbnail preference.
+  const preferPosterArtwork = cardStyle !== "card";
   const isNextUp = Boolean(options.isNextUp);
   const hasAired = options.hasAired !== false;
 
-  if (String(options.cardStyle || "card") === "poster") {
-    return [poster, backdrop, background];
+  if (preferPosterArtwork) {
+    if (useEpisodeThumbnails) {
+      return [isNextUp ? thumbnail : episodeThumbnail, poster, backdrop];
+    }
+    return [poster, backdrop];
   }
 
-  if (continueWatchingUsesEpisodeThumbnails(options.cardStyle, options.useEpisodeThumbnails)) {
-    if (!isNextUp) {
-      return [episodeThumbnail, backdrop, poster, thumbnail, background];
-    }
-    if (!hasAired) {
-      return [backdrop, poster, thumbnail, background, episodeThumbnail];
-    }
-    return [thumbnail, episodeThumbnail, backdrop, poster, background];
+  if (isNextUp && !hasAired) {
+    return [backdrop, poster, ...(useEpisodeThumbnails ? [thumbnail] : [])];
+  }
+  if (isNextUp && useEpisodeThumbnails) {
+    return [thumbnail, backdrop, poster];
+  }
+  if (useEpisodeThumbnails) {
+    return [episodeThumbnail, backdrop, poster];
   }
 
-  return [backdrop, poster, thumbnail, episodeThumbnail, background];
+  return [backdrop, poster];
 }

--- a/js/core/util/continueWatchingImage.test.mjs
+++ b/js/core/util/continueWatchingImage.test.mjs
@@ -29,7 +29,7 @@ test("poster style prefers poster then backdrop, never the episode still", () =>
     isNextUp: true,
     hasAired: true
   });
-  assert.deepEqual(sources, ["poster.jpg", "backdrop.jpg", "background.jpg"]);
+  assert.deepEqual(sources, ["poster.jpg", "backdrop.jpg"]);
   assert.ok(!sources.includes("episode.jpg"));
   assert.ok(!sources.includes("thumbnail.jpg"));
 });
@@ -41,13 +41,7 @@ test("card style with thumbnails on and not next up leads with the episode thumb
     isNextUp: false,
     hasAired: true
   });
-  assert.deepEqual(sources, [
-    "episode.jpg",
-    "backdrop.jpg",
-    "poster.jpg",
-    "thumbnail.jpg",
-    "background.jpg"
-  ]);
+  assert.deepEqual(sources, ["episode.jpg", "backdrop.jpg", "poster.jpg"]);
 });
 
 test("card style next up not aired keeps the episode still last", () => {
@@ -57,13 +51,7 @@ test("card style next up not aired keeps the episode still last", () => {
     isNextUp: true,
     hasAired: false
   });
-  assert.deepEqual(sources, [
-    "backdrop.jpg",
-    "poster.jpg",
-    "thumbnail.jpg",
-    "background.jpg",
-    "episode.jpg"
-  ]);
+  assert.deepEqual(sources, ["backdrop.jpg", "poster.jpg", "thumbnail.jpg"]);
 });
 
 test("card style next up aired leads with the thumbnail", () => {
@@ -73,43 +61,79 @@ test("card style next up aired leads with the thumbnail", () => {
     isNextUp: true,
     hasAired: true
   });
-  assert.deepEqual(sources, [
-    "thumbnail.jpg",
-    "episode.jpg",
-    "backdrop.jpg",
-    "poster.jpg",
-    "background.jpg"
-  ]);
+  assert.deepEqual(sources, ["thumbnail.jpg", "backdrop.jpg", "poster.jpg"]);
 });
 
-test("thumbnails off leads with the backdrop and keeps the episode still low", () => {
+test("thumbnails off excludes episode artwork from the fallback chain", () => {
   const sources = continueWatchingImageSources(art, {
     cardStyle: "card",
     useEpisodeThumbnails: false,
     isNextUp: false,
     hasAired: true
   });
-  assert.deepEqual(sources, [
-    "backdrop.jpg",
-    "poster.jpg",
-    "thumbnail.jpg",
-    "episode.jpg",
-    "background.jpg"
-  ]);
+  assert.deepEqual(sources, ["backdrop.jpg", "poster.jpg"]);
+  assert.ok(!sources.includes("episode.jpg"));
+  assert.ok(!sources.includes("thumbnail.jpg"));
 });
 
-test("wide style behaves like card style for the episode thumbnail order", () => {
+test("wide style uses poster-art ordering while thumbnails are enabled", () => {
   const wide = continueWatchingImageSources(art, {
     cardStyle: "wide",
     useEpisodeThumbnails: true,
     isNextUp: false,
     hasAired: true
   });
-  const card = continueWatchingImageSources(art, {
-    cardStyle: "card",
+  assert.deepEqual(wide, ["episode.jpg", "poster.jpg", "backdrop.jpg"]);
+});
+
+test("wide next up uses the next-up thumbnail before poster art", () => {
+  const sources = continueWatchingImageSources(art, {
+    cardStyle: "wide",
     useEpisodeThumbnails: true,
+    isNextUp: true,
+    hasAired: true
+  });
+  assert.deepEqual(sources, ["thumbnail.jpg", "poster.jpg", "backdrop.jpg"]);
+});
+
+test("wide style excludes thumbnails when the preference is disabled", () => {
+  const sources = continueWatchingImageSources(art, {
+    cardStyle: "wide",
+    useEpisodeThumbnails: false,
     isNextUp: false,
     hasAired: true
   });
-  assert.deepEqual(wide, card);
+  assert.deepEqual(sources, ["poster.jpg", "backdrop.jpg"]);
+});
+
+test("card style keeps an unaired next up thumbnail as a last resort", () => {
+  const sources = continueWatchingImageSources(art, {
+    cardStyle: "card",
+    useEpisodeThumbnails: true,
+    isNextUp: true,
+    hasAired: false
+  });
+  assert.deepEqual(sources, ["backdrop.jpg", "poster.jpg", "thumbnail.jpg"]);
+});
+
+test("card style with thumbnails disabled does not use an unaired next up thumbnail", () => {
+  const sources = continueWatchingImageSources(art, {
+    cardStyle: "card",
+    useEpisodeThumbnails: false,
+    isNextUp: true,
+    hasAired: false
+  });
+  assert.deepEqual(sources, ["backdrop.jpg", "poster.jpg"]);
+});
+
+test("card style normalization is case insensitive", () => {
+  assert.equal(continueWatchingUsesEpisodeThumbnails(" POSTER ", true), false);
+  assert.deepEqual(
+    continueWatchingImageSources(art, {
+      cardStyle: " WIDE ",
+      useEpisodeThumbnails: true,
+      isNextUp: false
+    }),
+    ["episode.jpg", "poster.jpg", "backdrop.jpg"]
+  );
 });

--- a/js/core/util/continueWatchingImage.test.mjs
+++ b/js/core/util/continueWatchingImage.test.mjs
@@ -1,0 +1,115 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  continueWatchingUsesEpisodeThumbnails,
+  continueWatchingImageSources
+} from "./continueWatchingImage.js";
+
+const art = {
+  poster: "poster.jpg",
+  backdrop: "backdrop.jpg",
+  thumbnail: "thumbnail.jpg",
+  episodeThumbnail: "episode.jpg",
+  background: "background.jpg"
+};
+
+test("poster style disables episode thumbnails regardless of the setting", () => {
+  assert.equal(continueWatchingUsesEpisodeThumbnails("poster", true), false);
+  assert.equal(continueWatchingUsesEpisodeThumbnails("card", true), true);
+  assert.equal(continueWatchingUsesEpisodeThumbnails("wide", true), true);
+  assert.equal(continueWatchingUsesEpisodeThumbnails("card", false), false);
+  assert.equal(continueWatchingUsesEpisodeThumbnails(undefined, true), true);
+});
+
+test("poster style prefers poster then backdrop, never the episode still", () => {
+  const sources = continueWatchingImageSources(art, {
+    cardStyle: "poster",
+    useEpisodeThumbnails: true,
+    isNextUp: true,
+    hasAired: true
+  });
+  assert.deepEqual(sources, ["poster.jpg", "backdrop.jpg", "background.jpg"]);
+  assert.ok(!sources.includes("episode.jpg"));
+  assert.ok(!sources.includes("thumbnail.jpg"));
+});
+
+test("card style with thumbnails on and not next up leads with the episode thumbnail", () => {
+  const sources = continueWatchingImageSources(art, {
+    cardStyle: "card",
+    useEpisodeThumbnails: true,
+    isNextUp: false,
+    hasAired: true
+  });
+  assert.deepEqual(sources, [
+    "episode.jpg",
+    "backdrop.jpg",
+    "poster.jpg",
+    "thumbnail.jpg",
+    "background.jpg"
+  ]);
+});
+
+test("card style next up not aired keeps the episode still last", () => {
+  const sources = continueWatchingImageSources(art, {
+    cardStyle: "card",
+    useEpisodeThumbnails: true,
+    isNextUp: true,
+    hasAired: false
+  });
+  assert.deepEqual(sources, [
+    "backdrop.jpg",
+    "poster.jpg",
+    "thumbnail.jpg",
+    "background.jpg",
+    "episode.jpg"
+  ]);
+});
+
+test("card style next up aired leads with the thumbnail", () => {
+  const sources = continueWatchingImageSources(art, {
+    cardStyle: "card",
+    useEpisodeThumbnails: true,
+    isNextUp: true,
+    hasAired: true
+  });
+  assert.deepEqual(sources, [
+    "thumbnail.jpg",
+    "episode.jpg",
+    "backdrop.jpg",
+    "poster.jpg",
+    "background.jpg"
+  ]);
+});
+
+test("thumbnails off leads with the backdrop and keeps the episode still low", () => {
+  const sources = continueWatchingImageSources(art, {
+    cardStyle: "card",
+    useEpisodeThumbnails: false,
+    isNextUp: false,
+    hasAired: true
+  });
+  assert.deepEqual(sources, [
+    "backdrop.jpg",
+    "poster.jpg",
+    "thumbnail.jpg",
+    "episode.jpg",
+    "background.jpg"
+  ]);
+});
+
+test("wide style behaves like card style for the episode thumbnail order", () => {
+  const wide = continueWatchingImageSources(art, {
+    cardStyle: "wide",
+    useEpisodeThumbnails: true,
+    isNextUp: false,
+    hasAired: true
+  });
+  const card = continueWatchingImageSources(art, {
+    cardStyle: "card",
+    useEpisodeThumbnails: true,
+    isNextUp: false,
+    hasAired: true
+  });
+  assert.deepEqual(wide, card);
+});

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -19,6 +19,10 @@ import { mapWithConcurrency } from "../../../core/network/mapWithConcurrency.js"
 import { filterReleasedItems } from "../../../core/util/releaseInfoUtils.js";
 import { LayoutPreferences } from "../../../data/local/layoutPreferences.js";
 import { showHomeRatings } from "../../../core/util/imdbRatingVisibility.js";
+import {
+  continueWatchingUsesEpisodeThumbnails,
+  continueWatchingImageSources
+} from "../../../core/util/continueWatchingImage.js";
 import { ContinueWatchingPreferences } from "../../../data/local/continueWatchingPreferences.js";
 import { HomeCatalogStore } from "../../../data/local/homeCatalogStore.js";
 import { CollectionsStore, buildCollectionHomeKey } from "../../../data/local/collectionsStore.js";
@@ -2359,40 +2363,28 @@ function renderContinueWatchingCard(item, index, options = {}) {
   const subtitle = normalized.episodeTitle || "";
   const isNextUp = Boolean(normalized?.isNextUp);
   const hasAired = normalized?.hasAired !== false;
-  const useEpisodeThumbnails = options?.useEpisodeThumbnails !== false;
+  const cardStyle = options?.cardStyle;
+  const useEpisodeThumbnails = continueWatchingUsesEpisodeThumbnails(
+    cardStyle,
+    options?.useEpisodeThumbnails
+  );
   const blurNextUp = Boolean(options?.blurNextUp && isNextUp && useEpisodeThumbnails);
   const rowKey = String(options?.rowKey || "continue_watching").trim() || "continue_watching";
-  const cardImageSources = useEpisodeThumbnails
-    ? !isNextUp
-      ? [
-          normalized.episodeThumbnail,
-          normalized.backdrop,
-          normalized.poster,
-          normalized.thumbnail,
-          normalized.background
-        ]
-      : !hasAired
-        ? [
-            normalized.backdrop,
-            normalized.poster,
-            normalized.thumbnail,
-            normalized.background,
-            normalized.episodeThumbnail
-          ]
-        : [
-            normalized.thumbnail,
-            normalized.episodeThumbnail,
-            normalized.backdrop,
-            normalized.poster,
-            normalized.background
-          ]
-    : [
-        normalized.backdrop,
-        normalized.poster,
-        normalized.thumbnail,
-        normalized.episodeThumbnail,
-        normalized.background
-      ];
+  const cardImageSources = continueWatchingImageSources(
+    {
+      poster: normalized.poster,
+      backdrop: normalized.backdrop,
+      thumbnail: normalized.thumbnail,
+      episodeThumbnail: normalized.episodeThumbnail,
+      background: normalized.background
+    },
+    {
+      cardStyle,
+      useEpisodeThumbnails: options?.useEpisodeThumbnails,
+      isNextUp,
+      hasAired
+    }
+  );
   const uniqueCardImageSources = uniqueNonEmptyValues(cardImageSources);
   const cardImage = uniqueCardImageSources[0] || "";
   const fallbackQueue = encodeHeroBackdropFallbacks(uniqueCardImageSources.slice(1));
@@ -2469,15 +2461,16 @@ export function renderContinueWatchingSection(items = [], options = {}) {
     1,
     Math.min(10, Number(options?.loadingCount || items.length || 3))
   );
-  const cardOptions = {
-    useEpisodeThumbnails: options?.useEpisodeThumbnails,
-    blurNextUp: options?.blurNextUp,
-    rowKey
-  };
   const itemLimit = Math.max(1, Number(options?.itemLimit || items.length || 1));
   const cardStyle = ["card", "wide", "poster"].includes(String(options?.cardStyle || "card"))
     ? String(options.cardStyle)
     : "card";
+  const cardOptions = {
+    useEpisodeThumbnails: options?.useEpisodeThumbnails,
+    blurNextUp: options?.blurNextUp,
+    cardStyle,
+    rowKey
+  };
   const renderedItems = getContinueWatchingRenderItems(items, itemLimit);
   return `
     <section class="home-row home-row-continue home-row-continue-${cardStyle}"${rowKey ? ` data-row-key="${escapeAttribute(rowKey)}"` : ""}>
@@ -11060,6 +11053,7 @@ export const HomeScreen = {
     const cardOptions = {
       useEpisodeThumbnails: this.layoutPrefs?.useEpisodeThumbnailsInCw !== false,
       blurNextUp: resolveContinueWatchingBlurNextUp(this.layoutPrefs),
+      cardStyle: this.layoutPrefs?.continueWatchingCardStyle || "card",
       rowKey
     };
     const markup = nextItems

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -2375,8 +2375,7 @@ function renderContinueWatchingCard(item, index, options = {}) {
       poster: normalized.poster,
       backdrop: normalized.backdrop,
       thumbnail: normalized.thumbnail,
-      episodeThumbnail: normalized.episodeThumbnail,
-      background: normalized.background
+      episodeThumbnail: normalized.episodeThumbnail
     },
     {
       cardStyle,


### PR DESCRIPTION
## Summary

With the Continue Watching card style set to "Poster" the web app still showed the landscape episode still cropped into the portrait poster shape. It should show the poster. The Android app treats poster style as poster art and ignores the episode thumbnail setting. This makes the web do the same.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode

## Why

The Continue Watching card picked its image without considering the card style. Episode thumbnails default on, so with the "Poster" card style a series card showed the episode still or backdrop squeezed into a 2:3 poster frame instead of the poster.

The image selection now follows the Android `continueWatchingUsesEpisodeThumbnails` and `continueWatchingImageModel` rules. Poster cards disable episode thumbnails; wide cards use the Android poster-art path while still honoring the thumbnail preference; card and wide fallback ordering follows the Android model.

## Issue or approval

No linked issue. This is a maintainer-approved Android parity fix, covered by the Android `ContinueWatchingImageModelTest` behavior.

## Reproduction steps

1. Open Settings, Layout, Continue Watching and set the card style to "Poster".
2. Keep "Use episode thumbnails" on (the default).
3. Open the home screen with a show in Continue Watching.
4. The card shows the episode still or backdrop cropped to a poster shape instead of the poster.

## Old behavior

Poster style cards showed the landscape episode still or backdrop cropped into the portrait poster frame. The web fallback chain could also retain episode artwork when the thumbnail preference was disabled.

## New behavior

Poster style cards show the poster, then the backdrop as a fallback. Wide cards use poster-art ordering like Android and respect the episode-thumbnail preference. Card-style rows keep the Android card ordering, and disabling episode thumbnails removes episode artwork from the fallback chain.

## Platform impact

- Samsung Tizen: shared code, same fix
- LG webOS: shared code, same fix
- Browser development mode: same fix
- Installer / packaging: none
- Wrapper repositories: none

## UI / behavior / playback impact

- [x] No playback change
- [x] Behavior changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I listed the testing performed below.

## Scope boundaries

The image selection now runs through a small shared helper that mirrors the Android source order for card, wide, and poster styles. Poster style also stops blurring the next up card because its effective thumbnail setting is disabled, matching Android.

## Testing

### Devices / platforms tested

Chrome on macOS was reported by the author. The Android source and `ContinueWatchingImageModelTest` were compared directly; the Android unit test was not rerun here because no Android SDK is configured in the environment.

### Commands tested

```sh
npm run build
npm run lint
node --check js/core/util/continueWatchingImage.js
node --check js/ui/screens/home/homeScreen.js
node --test js/core/util/continueWatchingImage.test.mjs
prettier --check js/core/util/continueWatchingImage.js js/core/util/continueWatchingImage.test.mjs js/ui/screens/home/homeScreen.js
git diff --check
```

## Manual test flow

Set the Continue Watching card style to Poster with episode thumbnails on. The expected result is poster artwork rather than an episode still cropped to a poster shape. Also verify Wide with thumbnails on/off and Card with thumbnails off; all three paths now follow the Android ordering.

## Screenshots / Video

Not provided.

## Logs

Not applicable.

## Regression risk

Low. The change is limited to Continue Watching artwork selection and the style/preference handoff. The source-order matrix is covered by 12 Node tests, including poster, wide, card, aired/unaired next-up, and thumbnails-off cases.

## Breaking changes

None.

## Linked issues

No linked issue. Maintainer-approved Android parity fix.
