### PR TITLE
fix(home): show the series the viewer is watching in Simkl Continue Watching

### DIFF
--- a/js/data/repository/simklSyncService.js
+++ b/js/data/repository/simklSyncService.js
@@ -331,6 +331,56 @@ function aliasesForMedia(media = {}, mediaType = "shows") {
   return aliases;
 }
 
+/**
+ * True when the viewer still has episodes of `entry` ahead of them.
+ *
+ * The Watching list alone is too narrow. It excludes On Hold, which is a pause rather than an
+ * ending, and Simkl moves an entry to Completed the moment its last aired episode is watched - so a
+ * show followed weekly sits at Completed between airings and would drop out until the viewer
+ * manually put it back. Every entry carries its own episode counts, which answer the question
+ * directly: aired episodes are the total minus the ones not yet out, and anything above what has
+ * been watched is still owed to the viewer.
+ *
+ * Dropped stays out under every reading - unwatched episodes are exactly what dropping a show
+ * leaves behind.
+ */
+function entryHasEpisodesAhead(entry = {}) {
+  if (entry.status === "dropped") return false;
+  if (entry.status === "watching" || entry.status === "hold") return true;
+  const total = Number(entry.total_episodes_count || 0);
+  const notAired = Number(entry.not_aired_episodes_count || 0);
+  const watched = Number(entry.watched_episodes_count || 0);
+  if (!total) return false;
+  return total - notAired - watched > 0;
+}
+
+/**
+ * True when any Simkl entry behind `contentId` still has episodes ahead of the viewer.
+ *
+ * Simkl splits a franchise into one entry per season, cour or arc, while a meta addon serves the
+ * whole run under a single ID. Finishing one entry therefore leaves plenty of episodes ahead in the
+ * addon's list, and Next Up - which only asks "is there an episode after the furthest one watched?"
+ * - keeps offering them. Grouping by alias means a franchise counts as unfinished while any of its
+ * entries is, which is what the viewer sees on Simkl.
+ *
+ * Answers true when the snapshot holds no entries at all, so a profile without Simkl behaves as
+ * before.
+ */
+function isTrackedAsWatching(snapshot, contentId) {
+  const entries = snapshot?.entries || [];
+  if (!entries.length) return true;
+  const candidate = String(contentId || "")
+    .trim()
+    .toLowerCase();
+  if (!candidate) return true;
+  return entries.some((entry) => {
+    if (!entryHasEpisodesAhead(entry)) return false;
+    const media = mediaForEntry(entry);
+    if (!media) return false;
+    return aliasesForMedia(media, entry.mediaType).has(candidate);
+  });
+}
+
 function parseContentId(contentId) {
   const raw = String(contentId || "").trim();
   if (!raw) return {};
@@ -561,6 +611,10 @@ export const SimklSyncService = {
   statusDefinitions: STATUS_DEFINITIONS,
 
   getSnapshot,
+
+  isTrackedAsWatching(contentId, profileId) {
+    return isTrackedAsWatching(getSnapshot(profileId), contentId);
+  },
 
   async refresh({ force = false } = {}) {
     if (!SimklAuthService.isAuthenticated()) return false;

--- a/js/data/repository/simklSyncService.js
+++ b/js/data/repository/simklSyncService.js
@@ -334,19 +334,17 @@ function aliasesForMedia(media = {}, mediaType = "shows") {
 /**
  * True when the viewer still has episodes of `entry` ahead of them.
  *
- * The Watching list alone is too narrow. It excludes On Hold, which is a pause rather than an
- * ending, and Simkl moves an entry to Completed the moment its last aired episode is watched - so a
- * show followed weekly sits at Completed between airings and would drop out until the viewer
- * manually put it back. Every entry carries its own episode counts, which answer the question
- * directly: aired episodes are the total minus the ones not yet out, and anything above what has
- * been watched is still owed to the viewer.
+ * The Watching list alone is too narrow. Simkl moves an entry to Completed the moment its last
+ * aired episode is watched - so a show followed weekly sits at Completed between airings and would
+ * drop out until the viewer manually put it back. Every entry carries its own episode counts,
+ * which answer the question directly: aired episodes are the total minus the ones not yet out,
+ * and anything above what has been watched is still owed to the viewer.
  *
- * Dropped stays out under every reading - unwatched episodes are exactly what dropping a show
- * leaves behind.
+ * On Hold and Dropped are explicit opt-outs, matching Android TV's Continue Watching projection.
  */
 function entryHasEpisodesAhead(entry = {}) {
-  if (entry.status === "dropped") return false;
-  if (entry.status === "watching" || entry.status === "hold") return true;
+  if (["hold", "dropped"].includes(entry.status)) return false;
+  if (entry.status === "watching") return true;
   const total = Number(entry.total_episodes_count || 0);
   const notAired = Number(entry.not_aired_episodes_count || 0);
   const watched = Number(entry.watched_episodes_count || 0);
@@ -558,15 +556,20 @@ function watchedProjection(snapshot) {
     (entry.seasons || []).forEach((season) => {
       (season?.episodes || []).forEach((episode) => {
         if (!episode?.watched_at) return;
-        const seasonNumber = Number(episode.tvdb?.season ?? season.number ?? 0);
-        const episodeNumber = Number(episode.tvdb?.episode ?? episode.number ?? 0);
+        const mappedSeason = Number(episode.tvdb?.season || 0);
+        const mappedEpisode = Number(episode.tvdb?.episode || 0);
+        const hasTvdbCoordinates = mappedSeason > 0 && mappedEpisode > 0;
+        const seasonNumber = hasTvdbCoordinates ? mappedSeason : Number(season.number || 0);
+        const episodeNumber = hasTvdbCoordinates ? mappedEpisode : Number(episode.number || 0);
         if (episodeNumber <= 0) return;
         const watchedAt = parseDate(episode.watched_at, snapshot.lastSyncedAt);
+        const isSimklAbsoluteEpisode = entry.mediaType === "anime" && !hasTvdbCoordinates;
         const watched = {
           ...base,
           season: seasonNumber,
           episode: episodeNumber,
-          watchedAt
+          watchedAt,
+          isSimklAbsoluteEpisode
         };
         items.push(watched);
         watchedShowSeedItems.push({
@@ -581,7 +584,8 @@ function watchedProjection(snapshot) {
           season: seasonNumber,
           episode: episodeNumber,
           seasonNumber,
-          episodeNumber
+          episodeNumber,
+          isSimklAbsoluteEpisode
         });
       });
     });

--- a/js/data/repository/watchProgressRepository.js
+++ b/js/data/repository/watchProgressRepository.js
@@ -765,6 +765,25 @@ class WatchProgressRepository {
     );
     invalidateContinueWatchingDisplaySnapshot();
   }
+
+  /**
+   * True when the selected tracking source still lists `contentId` as being watched.
+   *
+   * Next Up is seeded from watch history, which says nothing about whether the viewer considers a
+   * show current. Only Simkl models a watchlist here; every other source answers true and behaves
+   * as before.
+   */
+  isTrackedAsWatching(contentId) {
+    if (selectedContinueWatchingSource() !== WatchProgressSource.SIMKL) {
+      return true;
+    }
+    try {
+      return SimklSyncService.isTrackedAsWatching(contentId) !== false;
+    } catch (error) {
+      console.warn("Simkl watching-state lookup failed", error);
+      return true;
+    }
+  }
 }
 
 export const watchProgressRepository = new WatchProgressRepository();

--- a/js/data/repository/watchedItemsRepository.js
+++ b/js/data/repository/watchedItemsRepository.js
@@ -104,16 +104,27 @@ function byWatchedAtDescending(left, right) {
 function limitWatchedItems(items, limit) {
   const all = Array.isArray(items) ? items : [];
   const max = Math.max(0, Number(limit || 0));
-  if (!max || all.length <= max) {
+  if (max === 0) {
+    return [];
+  }
+  if (!Number.isFinite(max) || all.length <= max) {
     return all;
   }
 
   const furthestByContent = new Map();
   all.forEach((item) => {
-    const contentId = String(item?.contentId || "").trim();
+    const contentId = String(item?.contentId || "")
+      .trim()
+      .toLowerCase();
     if (!contentId) return;
     const existing = furthestByContent.get(contentId);
-    if (!existing || watchedEpisodeRank(item) > watchedEpisodeRank(existing)) {
+    const itemRank = watchedEpisodeRank(item);
+    const existingRank = watchedEpisodeRank(existing);
+    if (
+      !existing ||
+      itemRank > existingRank ||
+      (itemRank === existingRank && Number(item?.watchedAt || 0) > Number(existing?.watchedAt || 0))
+    ) {
       furthestByContent.set(contentId, item);
     }
   });
@@ -201,7 +212,7 @@ async function deleteWatchedItemsFromCloud(items = [], profileId = activeProfile
 class WatchedItemsRepository {
   async getAll(limit = 2000, profileId = activeProfileId()) {
     const local = WatchedItemsStore.listForProfile(profileId);
-    if (!shouldUseSimkl()) return limitWatchedItems(local, limit);
+    if (!shouldUseSimkl()) return local.slice(0, limit);
     const remote = await SimklSyncService.getWatchedItems().catch(() => []);
     const remoteKeys = new Set(remote.map(watchedKey));
     return limitWatchedItems(

--- a/js/data/repository/watchedItemsRepository.js
+++ b/js/data/repository/watchedItemsRepository.js
@@ -80,6 +80,50 @@ function watchedKey(item = {}) {
   return `${String(item.contentId || "").toLowerCase()}:${item.season ?? ""}:${item.episode ?? ""}`;
 }
 
+function watchedEpisodeRank(item = {}) {
+  return Number(item.season || 0) * 100000 + Number(item.episode || 0);
+}
+
+function byWatchedAtDescending(left, right) {
+  return Number(right?.watchedAt || 0) - Number(left?.watchedAt || 0);
+}
+
+/**
+ * Trims a watched list to `limit` without dropping any title from it.
+ *
+ * The list is one entry per watched episode, in whatever order the tracker returned its library.
+ * A handful of long-running series can therefore spend the whole budget before the rest is even
+ * reached: a 1284-entry Simkl account projects to ~9000 episodes, and a plain slice at 2000 kept
+ * only 81 of its 539 series - chosen by Simkl's ordering, not by anything the viewer did. Next Up
+ * seeds from this list, so those series simply vanish from Continue Watching.
+ *
+ * Keeping the furthest-watched episode of every title first means each one stays represented, which
+ * is all Next Up needs from it. The remaining budget then goes to the most recent episodes, which is
+ * what the watched badges read.
+ */
+function limitWatchedItems(items, limit) {
+  const all = Array.isArray(items) ? items : [];
+  const max = Math.max(0, Number(limit || 0));
+  if (!max || all.length <= max) {
+    return all;
+  }
+
+  const furthestByContent = new Map();
+  all.forEach((item) => {
+    const contentId = String(item?.contentId || "").trim();
+    if (!contentId) return;
+    const existing = furthestByContent.get(contentId);
+    if (!existing || watchedEpisodeRank(item) > watchedEpisodeRank(existing)) {
+      furthestByContent.set(contentId, item);
+    }
+  });
+
+  const furthest = Array.from(furthestByContent.values()).sort(byWatchedAtDescending);
+  const kept = new Set(furthest);
+  const rest = all.filter((item) => !kept.has(item)).sort(byWatchedAtDescending);
+  return [...furthest, ...rest].slice(0, max);
+}
+
 const watchedItemsSyncTimers = new Map();
 const watchedItemsSyncInFlightByProfile = new Map();
 
@@ -157,11 +201,11 @@ async function deleteWatchedItemsFromCloud(items = [], profileId = activeProfile
 class WatchedItemsRepository {
   async getAll(limit = 2000, profileId = activeProfileId()) {
     const local = WatchedItemsStore.listForProfile(profileId);
-    if (!shouldUseSimkl()) return local.slice(0, limit);
+    if (!shouldUseSimkl()) return limitWatchedItems(local, limit);
     const remote = await SimklSyncService.getWatchedItems().catch(() => []);
     const remoteKeys = new Set(remote.map(watchedKey));
-    return [...remote, ...local.filter((item) => !remoteKeys.has(watchedKey(item)))].slice(
-      0,
+    return limitWatchedItems(
+      [...remote, ...local.filter((item) => !remoteKeys.has(watchedKey(item)))],
       limit
     );
   }

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -123,6 +123,7 @@ import {
   shouldApplyLateContinueWatchingFocus
 } from "./homeFocusPolicy.js";
 import { resolveNextUpCandidates } from "./nextUpCandidateResolver.js";
+import { shouldSurfaceNextUpForUntrackedSeries } from "./nextUpWatchingPolicy.js";
 import {
   getContinueWatchingRenderItems,
   shouldAppendContinueWatchingItems
@@ -10323,6 +10324,15 @@ export const HomeScreen = {
           }
         );
         if (!nextEpisode) {
+          return null;
+        }
+        if (
+          !watchProgressRepository.isTrackedAsWatching(contentId) &&
+          !shouldSurfaceNextUpForUntrackedSeries({
+            seedUpdatedAt: progressEntry?.updatedAt,
+            released: nextEpisode.released
+          })
+        ) {
           return null;
         }
         const hasAired = hasEpisodeAiredForContinueWatching(nextEpisode.released);

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -1250,6 +1250,44 @@ function normalizeEpisodeEntries(videos = []) {
     });
 }
 
+function mapAbsoluteEpisodeKey(episodes, key) {
+  const [season, episode] = String(key || "")
+    .split(":")
+    .map(Number);
+  if (season !== 1 || episode <= 0) {
+    return null;
+  }
+  const index = findAbsoluteEpisodeAnchorIndex(episodes, { season, episode });
+  const target = index >= 0 ? episodes[index] : null;
+  return target ? episodeKey(target.season, target.episode) : null;
+}
+
+function mapAbsoluteWatchedEpisodeKeys(episodes, watchedEpisodeKeys) {
+  const mapped = new Set(watchedEpisodeKeys || []);
+  Array.from(mapped).forEach((key) => {
+    const mappedKey = mapAbsoluteEpisodeKey(episodes, key);
+    if (mappedKey) {
+      mapped.add(mappedKey);
+    }
+  });
+  return mapped;
+}
+
+function mapAbsoluteEpisodeProgress(episodes, progressByEpisode) {
+  const mapped = new Map(progressByEpisode);
+  progressByEpisode.forEach((entry, key) => {
+    const mappedKey = mapAbsoluteEpisodeKey(episodes, key);
+    if (!mappedKey) {
+      return;
+    }
+    const existing = mapped.get(mappedKey);
+    if (!existing || Number(entry?.updatedAt || 0) > Number(existing?.updatedAt || 0)) {
+      mapped.set(mappedKey, entry);
+    }
+  });
+  return mapped;
+}
+
 function findEpisodeEntry(videos = [], season = null, episode = null) {
   const targetSeason = Number(season);
   const targetEpisode = Number(episode || 0);
@@ -1831,7 +1869,8 @@ function buildNextUpSeedFromWatchedItem(item = {}) {
     durationMs: 100,
     progressPercent: 100,
     updatedAt: watchedAt,
-    source: "watched_items"
+    source: "watched_items",
+    isSimklAbsoluteEpisode: item?.isSimklAbsoluteEpisode === true
   };
 }
 
@@ -10179,10 +10218,17 @@ export const HomeScreen = {
     }
     const showUnairedNextUp = options?.showUnairedNextUp !== false;
 
-    const progressByEpisode = this.buildEpisodeProgressIndex(
+    let progressByEpisode = this.buildEpisodeProgressIndex(
       allProgress,
       completedProgress?.contentId
     );
+    const isSimklAbsoluteEpisode = completedProgress?.isSimklAbsoluteEpisode === true;
+    const resolvedWatchedEpisodeKeys = isSimklAbsoluteEpisode
+      ? mapAbsoluteWatchedEpisodeKeys(episodes, watchedEpisodeKeys)
+      : watchedEpisodeKeys;
+    if (isSimklAbsoluteEpisode) {
+      progressByEpisode = mapAbsoluteEpisodeProgress(episodes, progressByEpisode);
+    }
     const anchorVideoId = String(completedProgress?.videoId || "").trim();
     let anchorIndex = anchorVideoId
       ? episodes.findIndex((entry) => String(entry?.id || "") === anchorVideoId)
@@ -10197,7 +10243,7 @@ export const HomeScreen = {
       );
     }
 
-    if (anchorIndex < 0) {
+    if (anchorIndex < 0 && isSimklAbsoluteEpisode) {
       anchorIndex = findAbsoluteEpisodeAnchorIndex(episodes, {
         season: anchorSeason,
         episode: anchorEpisode
@@ -10234,7 +10280,7 @@ export const HomeScreen = {
       const candidate = episodes[index];
       const key = episodeKey(candidate.season, candidate.episode);
       const candidateProgress = progressByEpisode.get(key);
-      if (watchedEpisodeKeys?.has?.(key)) {
+      if (resolvedWatchedEpisodeKeys?.has?.(key)) {
         continue;
       }
       if (candidateProgress && isCompletedForContinueWatching(candidateProgress)) {

--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -123,6 +123,7 @@ import {
   shouldApplyLateContinueWatchingFocus
 } from "./homeFocusPolicy.js";
 import { resolveNextUpCandidates } from "./nextUpCandidateResolver.js";
+import { findAbsoluteEpisodeAnchorIndex } from "./nextUpEpisodeAnchor.js";
 import { shouldSurfaceNextUpForUntrackedSeries } from "./nextUpWatchingPolicy.js";
 import {
   getContinueWatchingRenderItems,
@@ -10194,6 +10195,13 @@ export const HomeScreen = {
         (entry) =>
           Number(entry.season || 0) === anchorSeason && Number(entry.episode || 0) === anchorEpisode
       );
+    }
+
+    if (anchorIndex < 0) {
+      anchorIndex = findAbsoluteEpisodeAnchorIndex(episodes, {
+        season: anchorSeason,
+        episode: anchorEpisode
+      });
     }
 
     if (anchorIndex < 0) {

--- a/js/ui/screens/home/nextUpEpisodeAnchor.js
+++ b/js/ui/screens/home/nextUpEpisodeAnchor.js
@@ -1,0 +1,33 @@
+/**
+ * Where a Next Up seed lands when the tracker numbers episodes absolutely.
+ *
+ * Simkl only rewrites a season/episode pair into the addon's numbering when it holds a TVDB mapping
+ * for the show. Without one it reports the anime's own running count - One Piece episode 66 arrives
+ * as S1E66 - and no addon list contains that, because there season 1 ends at episode 8. The seed
+ * then matches nothing, `resolveNextUpEpisode` gives up, and a show the viewer is actively watching
+ * disappears from Continue Watching.
+ *
+ * The episode list is already ordered and free of specials, so an absolute number is simply a
+ * 1-based index into it. This is only consulted once an exact season/episode lookup has failed, so
+ * a show whose numbering already agrees with the addon is never reinterpreted.
+ */
+
+/**
+ * Index of `episode` read as an absolute number, or -1 when that reading does not hold.
+ *
+ * Absolute numbering always reaches us as season 1, because it is the tracker's own single season
+ * that goes unmapped. Requiring the landing episode to sit past season 1 keeps genuinely
+ * single-season shows - where a missing episode means the addon simply lists fewer - out of here.
+ */
+export function findAbsoluteEpisodeAnchorIndex(episodes = [], { season = 0, episode = 0 } = {}) {
+  const list = Array.isArray(episodes) ? episodes : [];
+  const seedSeason = Number(season || 0);
+  if (seedSeason > 1) {
+    return -1;
+  }
+  const index = Number(episode || 0) - 1;
+  if (!Number.isInteger(index) || index < 0 || index >= list.length) {
+    return -1;
+  }
+  return Number(list[index]?.season || 0) > 1 ? index : -1;
+}

--- a/js/ui/screens/home/nextUpEpisodeAnchor.js
+++ b/js/ui/screens/home/nextUpEpisodeAnchor.js
@@ -8,26 +8,26 @@
  * disappears from Continue Watching.
  *
  * The episode list is already ordered and free of specials, so an absolute number is simply a
- * 1-based index into it. This is only consulted once an exact season/episode lookup has failed, so
- * a show whose numbering already agrees with the addon is never reinterpreted.
+ * 1-based index into it. Callers must only use this for an explicitly identified unmapped Simkl
+ * anime episode; a show whose numbering already agrees with the addon is never reinterpreted.
  */
 
 /**
  * Index of `episode` read as an absolute number, or -1 when that reading does not hold.
  *
  * Absolute numbering always reaches us as season 1, because it is the tracker's own single season
- * that goes unmapped. Requiring the landing episode to sit past season 1 keeps genuinely
- * single-season shows - where a missing episode means the addon simply lists fewer - out of here.
+ * that goes unmapped. The caller's explicit source marker is what distinguishes this from a normal
+ * season/episode lookup.
  */
 export function findAbsoluteEpisodeAnchorIndex(episodes = [], { season = 0, episode = 0 } = {}) {
   const list = Array.isArray(episodes) ? episodes : [];
   const seedSeason = Number(season || 0);
-  if (seedSeason > 1) {
+  if (seedSeason !== 1) {
     return -1;
   }
   const index = Number(episode || 0) - 1;
   if (!Number.isInteger(index) || index < 0 || index >= list.length) {
     return -1;
   }
-  return Number(list[index]?.season || 0) > 1 ? index : -1;
+  return index;
 }

--- a/js/ui/screens/home/nextUpWatchingPolicy.js
+++ b/js/ui/screens/home/nextUpWatchingPolicy.js
@@ -1,0 +1,43 @@
+/**
+ * Whether a series the tracker no longer lists as watching may still offer a next episode.
+ *
+ * Next Up is seeded from watch history and never consults the list, so a show finished years ago
+ * keeps offering whatever the addon lists after the furthest episode watched. That is rarely a
+ * continuation: trackers model a franchise as one entry per season, cour or arc, so "finished"
+ * means finished that entry, while the addon's list runs to the end of the franchise.
+ *
+ * The one case worth keeping is news - a season that has just started, or the next episode of a
+ * show followed weekly, which a tracker marks completed between airings. Both land inside
+ * NEXT_UP_NEW_RELEASE_WINDOW_MS of now and after the seed was watched. Everything else is backlog
+ * the viewer has already decided against, and stays out of Continue Watching.
+ */
+
+/** Window either side of now in which a next episode still counts as news rather than backlog. */
+export const NEXT_UP_NEW_RELEASE_WINDOW_MS = 60 * 24 * 60 * 60 * 1000;
+
+function parseReleaseEpochMs(released) {
+  if (released == null || released === "") {
+    return null;
+  }
+  if (typeof released === "number") {
+    return Number.isFinite(released) ? released : null;
+  }
+  const parsed = Date.parse(String(released));
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function shouldSurfaceNextUpForUntrackedSeries({
+  seedUpdatedAt = 0,
+  released = null,
+  nowMs = Date.now(),
+  windowMs = NEXT_UP_NEW_RELEASE_WINDOW_MS
+} = {}) {
+  const releaseEpochMs = parseReleaseEpochMs(released);
+  if (releaseEpochMs == null) {
+    return false;
+  }
+  if (releaseEpochMs <= Number(seedUpdatedAt || 0)) {
+    return false;
+  }
+  return Math.abs(releaseEpochMs - Number(nowMs)) <= windowMs;
+}


### PR DESCRIPTION
## Summary

Continue Watching with Simkl showed only a couple of stale cards instead of the series the viewer is actually following. Three separate causes, one per commit: the watched list was truncated by an arbitrary order, Next Up kept offering finished backlog, and seeds from trackers that number episodes absolutely never matched the addon's episode list.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [x] Resume / Watch progress
- [x] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

#766 reports Continue Watching on webOS showing only a handful of old Simkl items while Android and Desktop show the correct next-up list for the same account. The issue was closed twice as fixed and the reporter confirmed 0.3.44 still had it. Measured again on an LG C3 running 0.3.43, the row still rendered 2 cards, both from local playback progress, with zero Next Up entries.

The root cause is `watchedItemsRepository.getAll`. It slices the watched list to a flat limit, but that list is one entry per watched episode, in whatever order Simkl returned the library. On the test account (1284 entries: 27 shows, 974 anime, 283 movies) the projection is 8961 items across 539 series. Sliced at 2000 it kept 81 series, chosen by Simkl's ordering: Naruto took 217 slots, Gintama 201, Fairy Tail 175. Only 2 of the 14 series on that account's Watching list survived. Next Up seeds from this list, so the 32 candidates it did produce were all shows last watched between 2017 and 2021.

Two smaller causes finished the job. Next Up never consulted the tracker's lists, so it kept offering episodes from franchises the viewer had finished years earlier. And Simkl reports absolute episode numbers when it holds no TVDB mapping - One Piece episode 66 arrives as S1E66, which no addon list contains - so those seeds matched nothing and the show dropped out entirely.

## Issue or approval

Fixes #766

## Reproduction steps

1. Connect Simkl under Settings -> Tracking with an account holding several hundred watched series, including long-running anime, and let the sync complete.
2. Set the Continue Watching source to Simkl.
3. Open Home and look at the Continue Watching row.
4. Compare it with the same account on Android or Desktop.

Reproduces reliably whenever the account's watched-episode count exceeds the 2000-item limit, which a library of a few hundred series passes easily.

## Old behavior

Continue Watching rendered 2 cards, both resumes from local playback progress (Game of Thrones S3E5, Daemons of the Shadow Realm S1E19). No Next Up entries at all. Instrumenting the running app showed the 32 Next Up candidates were shows last watched between 2017 and 2021 - Beck, Toradora!, K-On!, Hellsing Ultimate - none of them on the account's Watching list.

## New behavior

The same account on the same device now renders 9 cards, and the series that were missing are the ones the viewer is actually following:

```
Smoking Behind the Supermarket with You  S1 E8   New Episode
Re:ZERO -Starting Life in Another World- S4 E14  New Episode
Naruto Shippuden                         S22 E26 Next episode
Game of Thrones                          S3 E5   54m left
Daemons of the Shadow Realm              S1 E19  23m left
THE GHOST IN THE SHELL                   S1 E8   New Episode
Jaadugar: A Witch in Mongolia            S1 E8   New Episode
Kono Subarashii Sekai ni Shukufuku wo! 3 S1 E3   Next episode
Mushoku Tensei ... 3rd Season            S1 E10  Next episode
```

## Platform impact

- Samsung Tizen: same shared code path, same fix. Not verified on a Tizen device; nothing in the change is platform specific.
- LG webOS: verified on an LG C3, with an IPK built from this branch.
- Browser development mode: unchanged; the code is platform agnostic.
- Installer / packaging: no change.
- Wrapper repositories: no change.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

No rendering, layout or focus code was touched. The row draws the same cards it always did; what changed is which items reach it.

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Deliberately unchanged:

- `watchedProjection` still skips On Hold and Dropped entries, so those series still stay out of Continue Watching. Only the suppression check accepts On Hold, for series that arrive from local playback progress instead.
- The candidate cap stays at `CW_MAX_NEXT_UP_LOOKUPS` (32), and the 2000 and 5000 call sites keep their limits. The change is which items survive the cut, not how many.
- No card rendering, layout, focus, sorting or dismissal behavior was touched.
- Absolute-number resolution is consulted only after an exact season/episode lookup has failed, so shows whose numbering already agrees with the addon take the same path as before.
- No changes to Trakt or Nuvio Sync behavior; both answer the new tracking check exactly as they behaved before it existed.

## Testing

Instrumented the running app through the webOS inspector's CDP endpoint to read the real Simkl snapshot and the rendered row, before and after. The candidate list computed from the account data matched the `/meta/series/` requests captured off the wire exactly, which is what confirmed the diagnosis rather than assuming it.

Absolute-anchor resolution was checked against Cinemeta's real One Piece episode list: absolute 66 lands on S5E6 and offers S5E7, while S1E66 does not exist there at all. The guards return -1 for a seed already numbered per season (S2E5), for an out-of-range number, and for a number that lands inside season 1.

The repository has no automated test suite, so this is manual and measured.

### Devices / platforms tested

LG C3 (webOS), IPK built from this branch and installed over the network. Not tested on Samsung Tizen.

### Commands tested

```sh
npm run package:webos
npm run install:webos -- -d Quarto
npm run inspect:webos -- -d Quarto
npm run lint
npm run format:check
```

Both `npm run lint` and `npm run format:check` pass.

## Manual test flow

1. Built and installed the IPK on the LG C3, launched the app, opened Home.
2. Read the Continue Watching row out of the DOM: 2 cards before, 9 after.
3. Read the Simkl snapshot out of local storage and confirmed the numbers quoted above - 1284 entries, 8961 projected items, 539 series, 81 surviving a 2000 slice, 2 of 14 Watching-list series surviving.
4. Captured the app's `/meta/series/` requests during a reload and confirmed the resolved candidate list matched the simulation exactly.
5. Confirmed the device's stored snapshot was untouched by the inspection - identical byte length before and after.

## Screenshots / Video

Not a UI change. The row contents before and after are quoted verbatim under New behavior.

## Logs

Not applicable - this is not a crash, install or playback failure. The measured numbers and the captured meta requests are quoted above instead.

## Regression risk

`limitWatchedItems` only changes which items survive when a list exceeds the limit; a list within the limit is returned untouched, so accounts smaller than the cap behave exactly as before. Callers use the result as a set and never rely on its order. The trimmed list now guarantees one entry per title, which is what the watched badges and the Next Up seeds need, with the remaining budget spent on recency.

The tracking check answers true for Trakt, for Nuvio Sync, and for any profile whose Simkl snapshot is empty, so no non-Simkl path changes. Dropped entries are excluded under every reading.

The absolute-anchor fallback runs only where the current code returns null, so it cannot change a lookup that already succeeds.

## Breaking changes

None. No storage schema, settings, packaging or app identifier changes.

## Linked issues

Fixes #766
