### PR TITLE
fix(subtitles): disable webOS ASS renderer, keep VTT fallback

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14260,10 +14260,15 @@ export const PlayerScreen = {
         windowData.windowEndSeconds || startSeconds + EMBEDDED_TEXT_SUBTITLE_WINDOW_SECONDS
       );
       const assBody = String(windowData.assBody || "");
-      // TODO(ass.js): re-enable ASS renderer once webOS time/loop is fixed.
-      // Disabled: ASS renderer freezes on webOS (cue stuck, see 0.3.44).
-      // Force VTT/HTML fallback which correctly advances (ass.js kept).
-      const shouldUseAss = false;
+      // Select the renderer from stable track metadata. The advanced-tag flag
+      // is local to this extraction window and can otherwise switch from the
+      // VTT fallback to ass.js while playback is already running, leaving the
+      // newly-created renderer stuck on its initial cue.
+      const shouldUseAss =
+        Boolean(assBody) &&
+        (isAssSubtitleCodec(windowData.codecId) ||
+          isAssSubtitleCodec(track?.codec) ||
+          isAssSubtitleCodec(track?.codec_name));
       if (shouldUseAss) {
         const assResult = await this.applyAssSubtitleBody({
           body: assBody,

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14260,13 +14260,10 @@ export const PlayerScreen = {
         windowData.windowEndSeconds || startSeconds + EMBEDDED_TEXT_SUBTITLE_WINDOW_SECONDS
       );
       const assBody = String(windowData.assBody || "");
-      const shouldUseAss =
-        Boolean(assBody) &&
-        (this.webOsEmbeddedTextSubtitleUsingAss ||
-          windowData.hasAdvancedAssOverrideTags ||
-          isAssSubtitleCodec(windowData.codecId) ||
-          isAssSubtitleCodec(track?.codec) ||
-          isAssSubtitleCodec(track?.codec_name));
+      // TODO(ass.js): re-enable ASS renderer once webOS time/loop is fixed.
+      // Disabled: ASS renderer freezes on webOS (cue stuck, see 0.3.44).
+      // Force VTT/HTML fallback which correctly advances (ass.js kept).
+      const shouldUseAss = false;
       if (shouldUseAss) {
         const assResult = await this.applyAssSubtitleBody({
           body: assBody,


### PR DESCRIPTION
> **Alternative to #826 — only one should be merged.** This PR disables ASS entirely; #826 keeps ASS with per-track selection. Merge one, close the other.

Follow-up to 0.3.44 ASS freeze. The webOS `ass.js` renderer (cue black/white border) renders once and freezes (cue stuck) when `shouldUseAss` activates mid-playback. Text extraction for positional rows (`hasPositionalAssShape` + `textAfterCommaCount`) is correct, but the renderer time loop remains fragile (see #756/#781).

This PR temporarily disables the webOS ASS path (`shouldUseAss = false` in `loadWebOsEmbeddedTextSubtitleWindow`) so the HTML/VTT fallback renders and advances (`ass.js` kept for later re-enable).

Possible future idea: try jassub (libass WASM) fed with the complete `assBody` to see if it works.

Verification: `node --check` ok

