### PR TITLE
fix(subtitles): select ASS backend per track, not per window (alternative to #825)

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14260,11 +14260,14 @@ export const PlayerScreen = {
         windowData.windowEndSeconds || startSeconds + EMBEDDED_TEXT_SUBTITLE_WINDOW_SECONDS
       );
       const assBody = String(windowData.assBody || "");
+      // Alternative: decide per track, not per window, to avoid mid-playback
+      // switch (VTT -> ASS) that freezes. hasAdvancedAssOverrideTags is window-
+      // local and triggers ass.js creation while video is already playing
+      // (play/playing already fired). Track codec is stable for the whole
+      // selection.
       const shouldUseAss =
         Boolean(assBody) &&
-        (this.webOsEmbeddedTextSubtitleUsingAss ||
-          windowData.hasAdvancedAssOverrideTags ||
-          isAssSubtitleCodec(windowData.codecId) ||
+        (isAssSubtitleCodec(windowData.codecId) ||
           isAssSubtitleCodec(track?.codec) ||
           isAssSubtitleCodec(track?.codec_name));
       if (shouldUseAss) {


### PR DESCRIPTION
> **Alternative to #825 — only one should be merged.** This PR keeps ASS per-track; #825 disables ASS entirely. Merge one, close the other.

Alternative to #825 (which disables ASS). Keeps `ass.js`, but makes the backend decision stable.

**Problem:** `shouldUseAss` included `windowData.hasAdvancedAssOverrideTags`, which is window-local (90s buckets). A track can flip from `false` (dialogue without tags) to `true` (typesetting with `\pos`/`\fad`) mid-playback, creating the ASS renderer while `play`/`playing` already fired → frozen cue (requires `play` re-dispatch `assRenderer.js` to advance).

**Alternative:** decide per track, not per window, using only the stable codec signal:

```js
shouldUseAss = Boolean(assBody) && (
  isAssSubtitleCodec(codecId) || isAssSubtitleCodec(track.codec) || isAssSubtitleCodec(track.codec_name)
)
```

- If the track is ASS (codec), always use ASS (or its VTT fallback if renderer fails).
- If not ASS, never use ASS.
- No mid-playback switch, no need to rely on `hasAdvancedAssOverrideTags` + `webOsEmbeddedTextSubtitleUsingAss` sticky flag.

Keeps `ass.js` for later fix of the time/loop.

Verification: `node --check` ok

