### PR TITLE
fix(subtitles): drive webOS ass.js frame loop with rAF

### DIFF
--- a/js/core/player/assRenderer.js
+++ b/js/core/player/assRenderer.js
@@ -52,7 +52,8 @@ export function createAssRenderer({
   container,
   selectionToken,
   isCurrentSelection,
-  resampling = "video_height"
+  resampling = "video_height",
+  forceRafFrameLoop = false
 }) {
   if (!body || !video || !container) {
     return { ok: false, error: "ass-renderer-missing-arguments" };
@@ -124,7 +125,27 @@ export function createAssRenderer({
             detail: "ASS body lacks an [Events] section with Dialogue rows"
           };
         }
-        instance = new AssConstructor(sourceBody, video, { container, resampling });
+        // webOS advertises requestVideoFrameCallback but never invokes it for
+        // its video pipeline (measured 0 callbacks over 6s of playback while
+        // requestAnimationFrame ticked normally), and ass.js schedules its
+        // frame loop on rVFC when present — so cues paint once and freeze
+        // (#844). Shadow the method while the constructor captures its frame
+        // scheduler so ass.js binds requestAnimationFrame instead, then
+        // restore the element.
+        const shadowRvfc =
+          forceRafFrameLoop &&
+          typeof video.requestVideoFrameCallback === "function" &&
+          !Object.prototype.hasOwnProperty.call(video, "requestVideoFrameCallback");
+        if (shadowRvfc) {
+          video.requestVideoFrameCallback = undefined;
+        }
+        try {
+          instance = new AssConstructor(sourceBody, video, { container, resampling });
+        } finally {
+          if (shadowRvfc) {
+            delete video.requestVideoFrameCallback;
+          }
+        }
         debugAssRender("constructed", {
           token,
           childCount: Number(container.childNodes?.length || 0),

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14045,7 +14045,10 @@ export const PlayerScreen = {
       video,
       container,
       selectionToken,
-      isCurrentSelection
+      isCurrentSelection,
+      // webOS never fires requestVideoFrameCallback for its video pipeline,
+      // which freezes the ass.js frame loop on its first paint (#844).
+      forceRafFrameLoop: Environment.isWebOS()
     });
     if (!renderer || typeof renderer.init !== "function") {
       return { applied: false, fallbackVtt: convertAssBodyToVtt(body) };


### PR DESCRIPTION
## Summary

On webOS, ASS subtitles rendered by ass.js paint their first cue and then freeze. Cause: webOS advertises `HTMLVideoElement.requestVideoFrameCallback` but never invokes it for its video pipeline, and ass.js schedules its frame loop on rVFC when present. This PR makes the ass.js instance bind `requestAnimationFrame` instead on webOS, by shadowing `requestVideoFrameCallback` on the video element only while the ass.js constructor captures its frame scheduler.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [x] Playback
- [ ] Audio tracks
- [x] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Measured on an LG TV (webOS, Chromium 120) with a remote web inspector attached to the running 1.0.1 app during playback of an embedded ASS track:

- `requestVideoFrameCallback` is present (`typeof` is `"function"`) but fired **0 times in 6 s** while the video played (`currentTime` advanced 1191.9 → 1197.9, 30 `timeupdate` events).
- `requestAnimationFrame` ticked **344 times** in the same 6 s.
- The ass.js container (`.ASS-box`) held the same cue text for 70+ s of advancing playback.

ass.js (assjs 0.1.10) prefers rVFC over rAF for its frame loop, so on webOS the loop never ticks. The only repaints come from `seeking` events, resizes, and the ~90 s embedded-extraction window reload recreating the instance, which is exactly the "stuck subtitle that refreshes when the player UI is opened" behavior reported. This is also the freeze that 14ada5b worked around by disabling the ASS renderer on webOS before fb41caa re-enabled it.

## Issue or approval

Possible fix for NuvioMedia/NuvioTVSmart#844.

## Reproduction steps

1. On a webOS TV, play media containing an embedded ASS/SSA subtitle track.
2. Select that subtitle track and let the video play without interaction.
3. Within one extraction window (~90 s), the subtitle freezes on one cue (or disappears), and reappears briefly when the timeline UI is opened or after a seek.

## Old behavior

ass.js paints the cue active at construction time and never advances. The frozen cue changes only when a seek, a resize, or the periodic extraction-window reload rebuilds the renderer, so subtitles appear stuck or missing most of the time, matching the linked issue.

## New behavior

The ass.js frame loop runs on `requestAnimationFrame` on webOS and cues advance continuously. Verified live on the TV: after applying the same element shadow at runtime through the inspector, the next renderer instance produced 23 correct cue transitions in 40 s, each matching `video.currentTime`.

## Platform impact

- Samsung Tizen: no behavior change; `forceRafFrameLoop` is passed as `Environment.isWebOS()`, so it is `false` on Tizen. Not tested on Tizen hardware.
- LG webOS: behavior change described above; validated on a real LG TV.
- Browser development mode: no behavior change (flag is `false`); rVFC continues to be used where it works.
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- The renderer selection logic (`shouldUseAss`, VTT fallback) is unchanged.
- A separate smaller defect is deliberately not touched: when an extraction window fails while ASS is active, `loadWebOsEmbeddedTextSubtitleWindow` tears the renderer down without restoring native subtitle visibility (`js/ui/screens/player/playerScreen.js:14370-14385`), leaving that window blank. Self-heals at the next window; can be a follow-up.
- No UI, styling, or selection-order changes.

## Testing

### Devices / platforms tested

- LG TV, webOS (Chromium 120), real hardware, embedded ASS track in an MKV stream.
- Honest limitation: the freeze diagnosis and the fix mechanism were validated live on the TV by applying the identical element shadow at runtime through the web inspector on the running 1.0.1 app (before: same cue for 70+ s; after: 23 correct cue transitions in 40 s). A package built from this branch has not yet been installed on the TV.
- Not tested on Tizen hardware (code path unreachable there, flag is `false`).

### Commands tested

```sh
npx prettier --check js/core/player/assRenderer.js js/ui/screens/player/playerScreen.js
npx eslint js/core/player/assRenderer.js js/ui/screens/player/playerScreen.js
node --test js/core/player/*.test.mjs   # 5/5 pass
```

## Manual test flow

Played an MKV stream with an embedded ASS subtitle track on the webOS app, selected the ASS track, and observed the overlay through the remote inspector while the video played untouched: cue text sampled every 500 ms, transitions compared against `video.currentTime` and the script's Dialogue timings.

## Screenshots / Video

Not a UI change (frame-loop timing only; rendered cue appearance is unchanged). Reproduction video of the freeze is in the linked issue.

## Logs

Inspector measurements from the running app during playback:

```
hasRVFC: "function", paused: false, readyState: 4
6 s window: rvfcTicks: 0, rafTicks: 344, timeupdate: 30, currentTime 1191.905 -> 1197.928
.ASS-box unchanged for 70+ s: "...by leaving Sea Prism Stone on one of my legs?"
after rAF fallback: 23 cue transitions in 40 s, aligned with currentTime
```

## Regression risk

- The shadow is an own property set only when `forceRafFrameLoop` is true, only while `new AssConstructor(...)` runs, and removed in a `finally`, so the element is unchanged afterwards even if the constructor throws (`js/core/player/assRenderer.js:104-124`).
- Nothing else in the codebase uses `requestVideoFrameCallback` (no matches in `js/`), and the bundled hls.js does not reference it, so shadowing cannot affect other consumers.
- assjs supports the rAF path by design; it is its own fallback for browsers without rVFC (`createFrame` in assjs 0.1.10).
- Tizen and browser mode pass `false` and keep the current behavior.

## Breaking changes

None.

## Linked issues

https://github.com/NuvioMedia/NuvioTVSmart/issues/844
