### PR TITLE
fix(subtitles): relax webOS positional ASS detection

### DIFF
--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1115,11 +1115,7 @@ function normalizeTextSubtitlePayload(track, payload) {
     !hasShortAssTiming &&
     fields.length >= 9 &&
     /^-?\d+$/.test(String(fields[0] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[1] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[4] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[5] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[6] || "").trim()) &&
-    String(fields[7] || "").trim() === "";
+    /^-?\d+$/.test(String(fields[1] || "").trim());
   if (hasLayeredAssTiming) {
     text = textAfterCommaCount(assEvent, 9) || "";
   } else if (hasShortAssTiming) {


### PR DESCRIPTION
Follow-up to #825 (ASS disabled). Even with ASS renderer disabled, the VTT fallback for positional ASS rows (`0,0,Style,Name,0,0,0,,text`) is still used via `normalizeTextSubtitlePayload`. The strict shape check (`fields 4,5,6 numeric + field 7 empty`) rejected variants with `Effect=Scroll` or non-numeric margins, falling back to raw prefix.

Relaxes `hasPositionalAssShape` to `isAssTrack && fields.length>=9 && numeric(fields[0]) && numeric(fields[1])` so more Flashback-style rows are extracted as text after 8 commas. Control rows (`Onscreen/Screen`) are still dropped via `isRawAssControlPayload`.

Verification: `node --check` ok, positional with `Scroll` now yields `text`, `Flashback` normal still `A large passenger jet`.
