### PR TITLE
fix(subtitles): always kick ASS frame loop on webOS

### DIFF
--- a/js/core/player/assRenderer.js
+++ b/js/core/player/assRenderer.js
@@ -167,7 +167,7 @@ export function createAssRenderer({
         // would freeze at its initial seek. Re-dispatch play (ass.js listens
         // to both play and playing, but the player binds only playing, so a
         // synthetic playing would trigger onPlaying side effects).
-        if (video && typeof video.paused === "boolean" && !video.paused) {
+        if (video && typeof video.dispatchEvent === "function") {
           try {
             // Legacy webOS runtimes may lack the Event constructor; fall back
             // to document.createEvent like PlayerController.emitVideoEvent.


### PR DESCRIPTION
Follow-up to 1.0.1 freeze: normal text → black-on-white ASS → frozen cue.

`ass.js` starts its frame loop only on `play`/`playing`. The renderer is created mid-playback when `shouldUseAss` flips to `true`, so those events already fired. The synthetic `play` dispatch was gated on `!video.paused` — on the webOS native pipeline that flag may not reflect real playback and the kick was skipped.

Change to `if (video && typeof video.dispatchEvent === "function")` (unconditional). Keeps legacy `Event` fallback. Does not touch `bitmapSubtitles` (already per-track from 0.3.44).

Verification: `node --check` ok
