### PR TITLE
fix(subtitles): relax positional ASS and always kick ASS loop on webOS

### DIFF
--- a/js/core/player/assRenderer.js
+++ b/js/core/player/assRenderer.js
@@ -167,7 +167,7 @@ export function createAssRenderer({
         // would freeze at its initial seek. Re-dispatch play (ass.js listens
         // to both play and playing, but the player binds only playing, so a
         // synthetic playing would trigger onPlaying side effects).
-        if (video && typeof video.paused === "boolean" && !video.paused) {
+        if (video && typeof video.dispatchEvent === "function") {
           try {
             // Legacy webOS runtimes may lack the Event constructor; fall back
             // to document.createEvent like PlayerController.emitVideoEvent.

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1115,11 +1115,7 @@ function normalizeTextSubtitlePayload(track, payload) {
     !hasShortAssTiming &&
     fields.length >= 9 &&
     /^-?\d+$/.test(String(fields[0] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[1] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[4] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[5] || "").trim()) &&
-    /^-?\d+$/.test(String(fields[6] || "").trim()) &&
-    String(fields[7] || "").trim() === "";
+    /^-?\d+$/.test(String(fields[1] || "").trim());
   if (hasLayeredAssTiming) {
     text = textAfterCommaCount(assEvent, 9) || "";
   } else if (hasShortAssTiming) {


### PR DESCRIPTION
Follow-up to 1.0.1/1.0.2 VTT freeze (`texto normal` congelado) and ASS freeze. PRs #825 (disabled) and #826 (per-track) are alternatives; this combines the needed parts.

**Fix 1 — positional VTT fallback:**
`hasPositionalAssShape` was `isAssTrack && >=9 && numeric(0,1,4,5,6) && field7==""`. Variant `0,0,Flash - Top,News,0,0,5,Scroll,text` failed → fell back to raw `assEvent` → prefijo crudo. Relax to `isAssTrack && >=9 && numeric(fields[0]) && numeric(fields[1])` so `textAfterCommaCount(assEvent,8)` extracts `text` with commas preserved. `Onscreen/Screen` control rows still dropped via `isRawAssControlPayload`.

**Fix 2 — ASS loop freeze (mid-playback VTT→ASS):**
`ass.js` starts its frame loop on `play`/`playing`. Renderer created mid-playback when `shouldUseAss` flips `true` → events already fired → cue congelada. Change `if (video && !video.paused)` to `if (video && typeof video.dispatchEvent === "function")` (unconditional `play` dispatch with legacy `document.createEvent` fallback). Keeps per-track selection stable (`isAssSubtitleCodec` already in `main`).

**Verification:** `node --check` ok, positional with `Scroll` → `text`, `Flashback` normal → `A large passenger jet`, control `533,0,Onscreen1...` still dropped, per-track stable, build not run per request.

Possible future idea: try jassub (libass WASM) fed with the complete `assBody`.
