### PR TITLE
fix(plugins): move plugin code cache from localStorage to IndexedDB

### DIFF
--- a/docs/plugin-runtime.md
+++ b/docs/plugin-runtime.md
@@ -84,16 +84,27 @@ il self-test QuickJS prima di diventare eseguibile.
 
 ## Stato, profili e sincronizzazione
 
-Lo stato è versionato e profile-scoped (`pluginState`); il codice è in una cache separata
-(`pluginCodeCache`) con chiavi hashate, limite dimensionale, LRU e recupero da entry corrotte.
+Lo stato è versionato e profile-scoped (`pluginState`); il codice è in una cache IndexedDB separata
+(`nuvio_plugin_code_cache`) con record per profilo e chiave hashata, limite dimensionale, LRU e
+recupero tollerante dagli errori. Se IndexedDB non è disponibile o fallisce, la cache usa memoria
+limitata alla sessione con le stesse quote. Le operazioni di pulizia (rimozione, svuotamento
+profilo, sign-out) restituiscono `false` e registrano un avviso quando la cancellazione persistente
+non può essere verificata; i record restano comunque nascosti per la sessione. In upgrade il
+vecchio payload localStorage `pluginCodeCache` viene eliminato una volta in modo idempotente, senza
+parsing o migrazione.
+Il cambiamento rimuove il percorso di persistenza sincrono che causava la regressione di reattività e
+quota su LG webOS 5.x; il comportamento di plugin, riproduzione e gli altri store localStorage resta
+invariato. La stessa cache asincrona viene usata anche sulle altre piattaforme Web TV.
 
 La cache del manifest/provider è il campo `metadata` dello stato del repository, con timestamp
 `lastUpdated`: non ha un TTL implicito e viene sostituita solo da un'aggiunta, da un refresh
 esplicito o da una riconciliazione cloud valida. Il codice JS è invalidato quando cambia il provider
 del manifest, la versione/URL viene risalvata o il repository viene rimosso; l'eviction è LRU e una
 scrittura viene verificata rileggendo l'entry, così un limite di storage non lascia un provider
-falsamente eseguibile. Non viene mantenuta una cache di bytecode compilato: l'asset QuickJS è parte
-immutabile del package e ogni esecuzione crea un contesto nuovo.
+falsamente eseguibile. Uno scraper con `codeAvailable: true` ma cache assente (ad esempio dopo
+un'eviction) non blocca l'esecuzione: il codice viene riscaricato al momento dell'uso. Non viene
+mantenuta una cache di bytecode compilato: l'asset QuickJS è parte immutabile del package e ogni
+esecuzione crea un contesto nuovo.
 
 - Il profilo principale è il profilo `1`.
 - Un profilo secondario con `usesPrimaryPlugins` legge il set principale e non può modificarlo o
@@ -237,7 +248,10 @@ eseguito almeno questo collaudo:
 8. verificare che add-on normali, playback, libreria, account e sync continuino a funzionare
    quando il plugin gate è negativo;
 9. raccogliere modello, versione OS/Web Engine, protocol handshake, memoria, log del servizio e
-   risultato QuickJS per ogni generazione.
+   risultato QuickJS per ogni generazione;
+10. su webOS 5.x, verificare che il salvataggio/lettura del codice provider nella cache IndexedDB
+    `nuvio_plugin_code_cache` non produca errori di quota o perdita di reattività, e che il vecchio
+    payload `pluginCodeCache` in localStorage non sia più presente.
 
 Finché questa matrice non è eseguita su dispositivi reali, la classificazione corretta è
 “candidato al runtime” e non “compatibile hardware”.

--- a/js/core/auth/authManager.js
+++ b/js/core/auth/authManager.js
@@ -3,6 +3,7 @@ import { clearAccountLocalData } from "./accountLocalDataReset.js";
 import { SessionStore } from "../storage/sessionStore.js";
 import { SUPABASE_ANON_KEY } from "../../config.js";
 import { fetchSupabaseAuth } from "./supabaseAuthFetch.js";
+import { PluginCodeStore } from "../../data/local/pluginCodeStore.js";
 
 function isJwtLike(token) {
   const value = String(token || "").trim();
@@ -158,6 +159,7 @@ class AuthManagerClass {
     } catch (error) {
       console.warn("Account-local data reset failed during sign out", error);
     }
+    await PluginCodeStore.clearAll();
     this.cachedEffectiveUserId = null;
     this.cachedEffectiveUserSourceUserId = null;
     if (!wasSignedOut) {

--- a/js/core/player/pluginManager.js
+++ b/js/core/player/pluginManager.js
@@ -204,33 +204,35 @@ export function resultToStream(result = {}, scraper = {}) {
   };
 }
 
-function mergeRepositoryScrapers(state, repository, manifest) {
+async function mergeRepositoryScrapers(state, repository, manifest) {
   const previous = state.scrapers.filter((entry) => entry.repositoryId === repository.id);
   const previousByKey = new Map(
     previous.map((entry) => [`${entry.manifestId || entry.filename}`, entry])
   );
-  const scrapers = manifest.scrapers.map((entry) => {
-    const id = scraperIdForManifest(repository.id, entry.id, entry.filename);
-    const old = previousByKey.get(`${entry.id}`) || previousByKey.get(`${entry.filename}`) || {};
-    return {
-      ...entry,
-      id,
-      repositoryId: repository.id,
-      manifestId: entry.id,
-      type: PLUGIN_REPOSITORY_TYPES.NUVIO_JS,
-      // Android keeps an existing user choice, but newly discovered
-      // VideoEasy providers start disabled until the user confirms the risk.
-      enabled:
-        old.enabled !== undefined
-          ? old.enabled
-          : entry.enabled !== false && !isVideoEasyScraper(entry.id, entry.name, entry.filename),
-      manifestEnabled: entry.enabled !== false,
-      codeAvailable: Boolean(PluginCodeStore.get(id)),
-      codeUrl: resolvePluginUrl(entry.codeUrl || entry.filename, repository.url),
-      supportedPlatforms: entry.supportedPlatforms || [],
-      disabledPlatforms: entry.disabledPlatforms || []
-    };
-  });
+  const scrapers = await Promise.all(
+    manifest.scrapers.map(async (entry) => {
+      const id = scraperIdForManifest(repository.id, entry.id, entry.filename);
+      const old = previousByKey.get(`${entry.id}`) || previousByKey.get(`${entry.filename}`) || {};
+      return {
+        ...entry,
+        id,
+        repositoryId: repository.id,
+        manifestId: entry.id,
+        type: PLUGIN_REPOSITORY_TYPES.NUVIO_JS,
+        // Android keeps an existing user choice, but newly discovered
+        // VideoEasy providers start disabled until the user confirms the risk.
+        enabled:
+          old.enabled !== undefined
+            ? old.enabled
+            : entry.enabled !== false && !isVideoEasyScraper(entry.id, entry.name, entry.filename),
+        manifestEnabled: entry.enabled !== false,
+        codeAvailable: Boolean(await PluginCodeStore.get(id)),
+        codeUrl: resolvePluginUrl(entry.codeUrl || entry.filename, repository.url),
+        supportedPlatforms: entry.supportedPlatforms || [],
+        disabledPlatforms: entry.disabledPlatforms || []
+      };
+    })
+  );
   return {
     ...state,
     repositories: [
@@ -496,7 +498,7 @@ async function classifyRemoteRepository(remote, quota) {
 }
 
 async function downloadCode(scraper, repository, quota) {
-  const existing = PluginCodeStore.get(scraper.id);
+  const existing = await PluginCodeStore.get(scraper.id);
   try {
     const response = await PluginServiceClient.fetch({
       url: scraper.codeUrl,
@@ -511,12 +513,12 @@ async function downloadCode(scraper, repository, quota) {
     if (!response.ok || response.truncated || !response.body.trim())
       throw new Error(`HTTP ${response.status || 0}`);
     if (
-      !PluginCodeStore.save(
+      !(await PluginCodeStore.save(
         scraper.id,
         response.body,
         { url: scraper.codeUrl, version: scraper.version },
         { maxBytes: quota.maxCacheBytes }
-      )
+      ))
     ) {
       throw new Error("Plugin code cache quota exceeded");
     }
@@ -532,11 +534,13 @@ async function hydrateJsRepository(state, repository, manifest, { markDirty = fa
   const previousIds = state.scrapers
     .filter((entry) => entry.repositoryId === repository.id)
     .map((entry) => entry.id);
-  let next = mergeRepositoryScrapers(state, repository, manifest);
+  let next = await mergeRepositoryScrapers(state, repository, manifest);
   const nextIds = new Set(
     next.scrapers.filter((entry) => entry.repositoryId === repository.id).map((entry) => entry.id)
   );
-  previousIds.filter((id) => !nextIds.has(id)).forEach((id) => PluginCodeStore.remove(id));
+  await Promise.all(
+    previousIds.filter((id) => !nextIds.has(id)).map((id) => PluginCodeStore.remove(id))
+  );
   const hydrated = [];
   for (const scraper of next.scrapers.filter((entry) => entry.repositoryId === repository.id)) {
     const codeAvailable = await downloadCode(scraper, repository, quota);
@@ -593,19 +597,26 @@ function externalScrapers(repository, metadata) {
   });
 }
 
-function clearRepositoryExecution(state, repositoryId) {
-  state.scrapers
-    .filter((entry) => entry.repositoryId === repositoryId)
-    .map((entry) => entry.id)
-    .forEach((id) => PluginCodeStore.remove(id));
+async function clearRepositoryExecution(state, repositoryId) {
+  await Promise.all(
+    state.scrapers
+      .filter((entry) => entry.repositoryId === repositoryId)
+      .map((entry) => PluginCodeStore.remove(entry.id))
+  );
   return {
     ...state,
     scrapers: state.scrapers.filter((entry) => entry.repositoryId !== repositoryId)
   };
 }
 
-function replaceRepositoryAsNonExecutable(state, existing, remote, detected, metadata = null) {
-  const cleaned = clearRepositoryExecution(state, existing.id);
+async function replaceRepositoryAsNonExecutable(
+  state,
+  existing,
+  remote,
+  detected,
+  metadata = null
+) {
+  const cleaned = await clearRepositoryExecution(state, existing.id);
   const type =
     detected.type === PLUGIN_REPOSITORY_TYPES.EXTERNAL_DEX
       ? PLUGIN_REPOSITORY_TYPES.EXTERNAL_DEX
@@ -643,7 +654,7 @@ async function hydrateDetectedJsRepository(state, existing, remote, detected) {
   const manifest =
     detected.manifest || normalizePluginManifest(await fetchJson(manifestUrl, quota), manifestUrl);
   if (!manifest) throw new Error("JS repository manifest is invalid");
-  const cleaned = clearRepositoryExecution(state, existing.id);
+  const cleaned = await clearRepositoryExecution(state, existing.id);
   return hydrateJsRepository(
     cleaned,
     {
@@ -716,7 +727,11 @@ async function executeOne(
   signal,
   { throwOnError = false, mapResults = true } = {}
 ) {
-  const code = PluginCodeStore.get(scraper.id);
+  let code = await PluginCodeStore.get(scraper.id);
+  if (!code?.code && scraper.codeUrl) {
+    await downloadCode(scraper, repository, quota);
+    code = await PluginCodeStore.get(scraper.id);
+  }
   if (!code?.code) return [];
   const executionProfileId = getEffectivePluginProfileId();
   const executionSettings = currentState().settings.scraperSettings?.[scraper.id] || {};
@@ -1039,7 +1054,7 @@ export const PluginManager = {
     return { ok: true };
   },
 
-  removeRepository(repositoryId) {
+  async removeRepository(repositoryId) {
     if (!canEdit()) return false;
     const state = currentState();
     const repository = state.repositories.find((entry) => entry.id === repositoryId);
@@ -1052,7 +1067,7 @@ export const PluginManager = {
     const scraperIds = state.scrapers
       .filter((entry) => entry.repositoryId === repositoryId)
       .map((entry) => entry.id);
-    scraperIds.forEach((id) => PluginCodeStore.remove(id));
+    await Promise.all(scraperIds.map((id) => PluginCodeStore.remove(id)));
     PluginStore.replace({
       ...state,
       repositories: state.repositories.filter((entry) => entry.id !== repositoryId),
@@ -1179,7 +1194,7 @@ export const PluginManager = {
               : null;
           // A typed remote transition is authoritative for execution policy:
           // remove any cached JS code before retaining the row as metadata-only.
-          next = replaceRepositoryAsNonExecutable(next, existing, remote, detected, external);
+          next = await replaceRepositoryAsNonExecutable(next, existing, remote, detected, external);
           continue;
         }
         if (
@@ -1243,14 +1258,16 @@ export const PluginManager = {
       const removed = next.repositories.filter(
         (entry) => !remoteIdentities.has(repositoryIdentity(entry.url))
       );
-      removed
-        .filter((entry) => entry.type === PLUGIN_REPOSITORY_TYPES.NUVIO_JS)
-        .flatMap((entry) =>
-          next.scrapers
-            .filter((scraper) => scraper.repositoryId === entry.id)
-            .map((scraper) => scraper.id)
-        )
-        .forEach((id) => PluginCodeStore.remove(id));
+      await Promise.all(
+        removed
+          .filter((entry) => entry.type === PLUGIN_REPOSITORY_TYPES.NUVIO_JS)
+          .flatMap((entry) =>
+            next.scrapers
+              .filter((scraper) => scraper.repositoryId === entry.id)
+              .map((scraper) => scraper.id)
+          )
+          .map((id) => PluginCodeStore.remove(id))
+      );
       // A DEX or future/opaque repository is outside this client's delete
       // authority. Keep it even when an older server response omits the row;
       // Android may execute/reconcile DEX locally, but Web must never turn a
@@ -1466,7 +1483,7 @@ export const PluginManager = {
   },
 
   async clearCache() {
-    PluginCodeStore.clear();
+    await PluginCodeStore.clear();
     PluginServiceClient.resetHealthCache();
     try {
       await PluginServiceClient.clearCache();

--- a/js/core/profile/profileSelectionScreen.js
+++ b/js/core/profile/profileSelectionScreen.js
@@ -2277,7 +2277,7 @@ export const ProfileSelectionScreen = {
     const deleted = await ProfileManager.deleteProfile(profile.id);
     if (deleted !== false) {
       PluginStore.clearProfile(profile.id);
-      PluginCodeStore.clearProfile(profile.id);
+      await PluginCodeStore.clearProfile(profile.id);
       await ProfileSyncService.deleteProfileData(profile.id);
       await ProfileSyncService.push();
       await this.refreshProfilePinStates();

--- a/js/data/local/pluginCodeStore.js
+++ b/js/data/local/pluginCodeStore.js
@@ -1,134 +1,303 @@
-import { createProfileScopedStore } from "./profileScopedStore.js";
 import { getEffectivePluginProfileId } from "./pluginStore.js";
 import { safePluginId, stablePluginHash } from "../../core/player/pluginModels.js";
 
-const CACHE_KEY = "pluginCodeCache";
+const LEGACY_CACHE_KEY = "pluginCodeCache";
+const DATABASE_NAME = "nuvio_plugin_code_cache";
+const DATABASE_VERSION = 1;
+const STORE_NAME = "code";
+// Every record key is `${profile}:plugin_...`; U+FFFF is the highest single
+// code unit, so this closed upper bound covers exactly one profile's keys.
+const PREFIX_UPPER_BOUND = "￿";
+const memoryEntries = new Map();
+const tombstonedPrefixes = new Set();
+let tombstoneAll = false;
+let databasePromise = null;
+let memoryFallback = false;
+let mutationQueue = Promise.resolve();
 
-function normalizeCache(raw) {
-  const entries =
-    raw?.entries && typeof raw.entries === "object" && !Array.isArray(raw.entries)
-      ? raw.entries
-      : {};
-  const normalized = {};
-  Object.entries(entries).forEach(([key, value]) => {
-    if (!value || typeof value !== "object" || typeof value.code !== "string") return;
-    const id = safePluginId(key, "plugin");
-    normalized[id] = {
-      code: value.code,
-      bytes: Number(value.bytes || value.code.length) || value.code.length,
-      url: String(value.url || ""),
-      version: String(value.version || ""),
-      updatedAt: Number(value.updatedAt || 0) || 0,
-      lastUsedAt: Number(value.lastUsedAt || value.updatedAt || 0) || 0
-    };
-  });
-  return { entries: normalized };
+try {
+  globalThis.localStorage?.removeItem(LEGACY_CACHE_KEY);
+} catch (_) {
+  // Cache cleanup must not prevent startup on a read-only storage area.
 }
 
-const scopedCache = createProfileScopedStore({ key: CACHE_KEY, normalize: normalizeCache });
+function canUseIndexedDb() {
+  return typeof globalThis.indexedDB !== "undefined";
+}
+
+// Once IndexedDB has failed, session memory is authoritative but persistent
+// records may still exist on disk. Where IndexedDB does not exist at all,
+// nothing persistent was ever written, so cleanup is trivially complete.
+function persistentCleanupUnverified() {
+  return canUseIndexedDb() && memoryFallback;
+}
+
+function openDatabase() {
+  if (!canUseIndexedDb()) return Promise.resolve(null);
+  if (databasePromise) return databasePromise;
+  databasePromise = new Promise((resolve) => {
+    let request;
+    try {
+      request = globalThis.indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+    } catch (_) {
+      resolve(null);
+      return;
+    }
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        database.createObjectStore(STORE_NAME, { keyPath: "key" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => resolve(null);
+    request.onblocked = () => resolve(null);
+  });
+  return databasePromise;
+}
 
 function cacheKey(scraperId) {
   const raw = String(scraperId || "plugin");
   return `plugin_${stablePluginHash(raw)}_${safePluginId(raw, "plugin", 24)}`;
 }
 
-function legacyCacheKey(scraperId) {
-  return safePluginId(scraperId, "plugin");
+function profileId(value) {
+  return getEffectivePluginProfileId(value);
 }
 
-function profileId(profileId) {
-  return getEffectivePluginProfileId(profileId);
+function recordKey(scraperId, profile) {
+  return `${String(profile)}:${cacheKey(scraperId)}`;
 }
 
-function totalBytes(entries) {
-  return Object.values(entries || {}).reduce(
-    (total, entry) => total + Number(entry?.bytes || 0),
-    0
-  );
+function byteLength(value) {
+  return typeof TextEncoder === "function"
+    ? new TextEncoder().encode(value).byteLength
+    : unescape(encodeURIComponent(value)).length;
+}
+
+function enqueue(operation) {
+  const result = mutationQueue.then(operation, operation);
+  mutationQueue = result.catch(() => undefined);
+  return result;
+}
+
+function transaction(mode, operation) {
+  return openDatabase().then((database) => {
+    if (!database) return { ok: false, value: null };
+    return new Promise((resolve) => {
+      try {
+        const tx = database.transaction(STORE_NAME, mode);
+        const value = operation(tx.objectStore(STORE_NAME));
+        tx.oncomplete = () => resolve({ ok: true, value });
+        tx.onerror = () => resolve({ ok: false, value: null });
+        tx.onabort = () => resolve({ ok: false, value: null });
+      } catch (_) {
+        resolve({ ok: false, value: null });
+      }
+    });
+  });
+}
+
+function isTombstoned(key) {
+  return tombstoneAll || [...tombstonedPrefixes].some((prefix) => key.startsWith(prefix));
+}
+
+async function readRecord(key) {
+  if (memoryFallback || isTombstoned(key)) {
+    return memoryEntries.get(key) || null;
+  }
+  const result = await transaction("readonly", (store) => {
+    const request = store.get(key);
+    return new Promise((resolve) => {
+      request.onsuccess = () => resolve(request.result || null);
+      request.onerror = () => resolve(null);
+    });
+  });
+  if (!result.ok) {
+    memoryFallback = true;
+    return memoryEntries.get(key) || null;
+  }
+  return result.value;
+}
+
+async function readProfileRecords(prefix) {
+  if (memoryFallback || tombstoneAll || tombstonedPrefixes.has(prefix)) {
+    return [...memoryEntries].filter(([key]) => key.startsWith(prefix));
+  }
+  const result = await transaction("readonly", (store) => {
+    const records = [];
+    const request = store.openCursor(
+      globalThis.IDBKeyRange.bound(prefix, `${prefix}${PREFIX_UPPER_BOUND}`)
+    );
+    return new Promise((resolve) => {
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) {
+          resolve(records);
+          return;
+        }
+        records.push([cursor.key, cursor.value]);
+        cursor.continue();
+      };
+      request.onerror = () => resolve(null);
+    });
+  });
+  if (!result.ok || !result.value) {
+    memoryFallback = true;
+    return [...memoryEntries].filter(([key]) => key.startsWith(prefix));
+  }
+  return result.value;
+}
+
+async function writeRecord(key, value) {
+  if (memoryFallback) {
+    memoryEntries.set(key, value);
+    return true;
+  }
+  const result = await transaction("readwrite", (store) => store.put({ ...value, key }));
+  if (!result.ok) {
+    memoryFallback = true;
+    memoryEntries.set(key, value);
+    return true;
+  }
+  memoryEntries.set(key, value);
+  return true;
+}
+
+// Returns whether persistent deletion is verified. The record is always gone
+// from this session's view; a false result means disk records may remain.
+async function deleteRecord(key) {
+  if (memoryFallback || isTombstoned(key)) {
+    memoryEntries.delete(key);
+    if (!persistentCleanupUnverified()) return true;
+    tombstonedPrefixes.add(key);
+    return false;
+  }
+  const result = await transaction("readwrite", (store) => store.delete(key));
+  memoryEntries.delete(key);
+  if (!result.ok) {
+    memoryFallback = true;
+    tombstonedPrefixes.add(key);
+    return false;
+  }
+  return true;
+}
+
+function bytesFor(records) {
+  return records.reduce((total, [, entry]) => total + Number(entry?.bytes || 0), 0);
+}
+
+function markPrefixTombstone(prefix) {
+  tombstonedPrefixes.add(prefix);
+  [...memoryEntries.keys()]
+    .filter((key) => key.startsWith(prefix))
+    .forEach((key) => memoryEntries.delete(key));
 }
 
 export const PluginCodeStore = {
   get(scraperId, profile) {
-    const key = cacheKey(scraperId);
-    const oldKey = legacyCacheKey(scraperId);
-    const state = scopedCache.getForProfile(profileId(profile));
-    const storedKey = state.entries[key] ? key : oldKey;
-    const entry = state.entries[storedKey];
-    if (!entry) return null;
-    const touched = { ...entry, lastUsedAt: Date.now() };
-    if (touched.lastUsedAt !== entry.lastUsedAt) {
-      const entries = { ...state.entries, [key]: touched };
-      if (storedKey !== key) delete entries[storedKey];
-      scopedCache.replaceForProfile(profileId(profile), { entries }, { silentSync: true });
-    }
-    return touched;
+    const key = recordKey(scraperId, profileId(profile));
+    return enqueue(async () => {
+      const entry = await readRecord(key);
+      if (!entry) return null;
+      const touched = { ...entry, lastUsedAt: Date.now() };
+      await writeRecord(key, touched);
+      return touched;
+    });
   },
 
   save(scraperId, code, metadata = {}, { maxBytes = 16 * 1024 * 1024, profile = null } = {}) {
-    const key = cacheKey(scraperId);
+    const id = profileId(profile);
+    const key = recordKey(scraperId, id);
     const value = String(code || "");
-    const bytes =
-      typeof TextEncoder === "function"
-        ? new TextEncoder().encode(value).byteLength
-        : unescape(encodeURIComponent(value)).length;
-    if (bytes > maxBytes) return false;
-    const state = scopedCache.getForProfile(profileId(profile));
-    const entries = { ...state.entries };
-    entries[key] = {
-      code: value,
-      bytes,
-      url: String(metadata.url || ""),
-      version: String(metadata.version || ""),
-      updatedAt: Date.now(),
-      lastUsedAt: Date.now()
-    };
-    delete entries[legacyCacheKey(scraperId)];
-    while (totalBytes(entries) > maxBytes) {
-      const oldest = Object.entries(entries)
-        .filter(([entryKey]) => entryKey !== key)
-        .sort(
-          ([, left], [, right]) => Number(left.lastUsedAt || 0) - Number(right.lastUsedAt || 0)
-        )[0];
-      if (!oldest) return false;
-      delete entries[oldest[0]];
-    }
-    try {
-      scopedCache.replaceForProfile(profileId(profile), { entries }, { silentSync: true });
-      // LocalStore deliberately absorbs quota/serialization errors. Verify the
-      // replacement so a full TV storage device cannot make a provider look
-      // executable until the next restart.
-      const persisted = scopedCache.getForProfile(profileId(profile));
-      return persisted.entries[key]?.code === value;
-    } catch (_) {
-      return false;
-    }
+    const bytes = byteLength(value);
+    if (bytes > maxBytes) return Promise.resolve(false);
+    return enqueue(async () => {
+      const records = await readProfileRecords(`${id}:`);
+      const now = Date.now();
+      const next = {
+        code: value,
+        bytes,
+        url: String(metadata.url || ""),
+        version: String(metadata.version || ""),
+        updatedAt: now,
+        lastUsedAt: now
+      };
+      const retained = new Map(records);
+      retained.set(key, next);
+      while (bytesFor([...retained]) > maxBytes) {
+        const oldest = [...retained]
+          .filter(([entryKey]) => entryKey !== key)
+          .sort(
+            ([, left], [, right]) => Number(left.lastUsedAt || 0) - Number(right.lastUsedAt || 0)
+          )[0];
+        if (!oldest) return false;
+        retained.delete(oldest[0]);
+      }
+      const evicted = records.filter(([entryKey]) => !retained.has(entryKey));
+      for (const [evictedKey] of evicted) await deleteRecord(evictedKey);
+      await writeRecord(key, next);
+      return (await readRecord(key))?.code === value;
+    });
   },
 
   remove(scraperId, profile) {
-    const key = cacheKey(scraperId);
-    const oldKey = legacyCacheKey(scraperId);
-    const state = scopedCache.getForProfile(profileId(profile));
-    if (!state.entries[key] && !state.entries[oldKey]) return false;
-    const entries = { ...state.entries };
-    delete entries[key];
-    delete entries[oldKey];
-    scopedCache.replaceForProfile(profileId(profile), { entries }, { silentSync: true });
-    return true;
+    const key = recordKey(scraperId, profileId(profile));
+    return enqueue(async () => {
+      const existed = Boolean(await readRecord(key));
+      if (!existed) return false;
+      const deleted = await deleteRecord(key);
+      if (!deleted) {
+        console.warn("Plugin code persistent removal failed; record hidden for this session", key);
+      }
+      return deleted;
+    });
   },
 
   clear(profile) {
-    scopedCache.replaceForProfile(profileId(profile), { entries: {} }, { silentSync: true });
+    const prefix = `${profileId(profile)}:`;
+    return enqueue(async () => {
+      const records = await readProfileRecords(prefix);
+      let success = !persistentCleanupUnverified();
+      for (const [key] of records) success = (await deleteRecord(key)) && success;
+      if (!success) {
+        markPrefixTombstone(prefix);
+        console.warn(
+          "Plugin code persistent clear failed; profile hidden for this session",
+          prefix
+        );
+      }
+      return success;
+    });
   },
 
   clearProfile(profile) {
-    const normalizedProfileId = String(profile || "").trim();
-    if (!normalizedProfileId || normalizedProfileId === "1") return false;
-    if (profileId(normalizedProfileId) !== normalizedProfileId) return false;
-    this.clear(normalizedProfileId);
-    return true;
+    const normalized = String(profile || "").trim();
+    if (!normalized || normalized === "1" || profileId(normalized) !== normalized) {
+      return Promise.resolve(false);
+    }
+    return this.clear(normalized);
+  },
+
+  clearAll() {
+    return enqueue(async () => {
+      memoryEntries.clear();
+      if (!canUseIndexedDb()) return true;
+      // Always attempt the persistent clear, even after an earlier failure:
+      // sign-out must not leave a previous account's plugin source on disk.
+      const result = await transaction("readwrite", (store) => store.clear());
+      if (!result.ok) {
+        memoryFallback = true;
+        tombstoneAll = true;
+        console.warn("Plugin code persistent clear failed; cache hidden for this session");
+        return false;
+      }
+      return true;
+    });
   },
 
   totalBytes(profile) {
-    return totalBytes(scopedCache.getForProfile(profile).entries);
+    const prefix = `${profileId(profile)}:`;
+    return enqueue(async () => bytesFor(await readProfileRecords(prefix)));
   }
 };

--- a/js/ui/screens/plugin/pluginsScreen.js
+++ b/js/ui/screens/plugin/pluginsScreen.js
@@ -662,7 +662,7 @@ export const PluginsScreen = {
       return;
     }
     if (kind === "remove") {
-      if (PluginManager.removeRepository(id)) {
+      if (await PluginManager.removeRepository(id)) {
         this.setStatus(t("plugin_repo_removed", {}, "Repository removed."), "success");
       }
       this.render();

--- a/scripts/test-plugin-system.mjs
+++ b/scripts/test-plugin-system.mjs
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import dns from "node:dns";
 import http from "node:http";
+import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
 import vm from "node:vm";
 import { createPluginHttpServer } from "../services/plugin-http.cjs";
 import {
@@ -45,6 +47,7 @@ import { Platform } from "../js/platform/index.js";
 import { buildPluginPushRows, mapRemotePluginRows } from "../js/core/profile/pluginSyncService.js";
 
 const root = new URL("..", import.meta.url);
+const execFileAsync = promisify(execFile);
 
 if (!globalThis.localStorage) {
   const testStorage = new Map();
@@ -421,7 +424,7 @@ async function testRawScraperTestContract() {
         settings: { pluginsEnabled: true, groupStreamsByRepository: false }
       })
     );
-    PluginCodeStore.save(
+    await PluginCodeStore.save(
       scraperId,
       "module.exports.getStreams = function(){ return []; };",
       {},
@@ -439,13 +442,363 @@ async function testRawScraperTestContract() {
   } finally {
     PluginManager.ensureRuntime = previousEnsureRuntime;
     PluginRuntime.executePlugin = previousExecutePlugin;
-    PluginCodeStore.remove(scraperId);
+    await PluginCodeStore.remove(scraperId);
     PluginStore.replace({ ...previousState, syncDirty: false });
     if (previousWorker === undefined) delete globalThis.Worker;
     else globalThis.Worker = previousWorker;
     if (previousAllowBrowser === undefined)
       delete globalThis.__NUVIO_ALLOW_BROWSER_PLUGIN_RUNTIME__;
     else globalThis.__NUVIO_ALLOW_BROWSER_PLUGIN_RUNTIME__ = previousAllowBrowser;
+  }
+}
+
+async function testPluginCodeCacheContract() {
+  await PluginCodeStore.clearAll();
+
+  const legacyProbe = await execFileAsync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `const calls = [];
+     const values = new Map([['pluginCodeCache', '{"entries":{"large":{"code":"x"}}}']]);
+     globalThis.localStorage = {
+       getItem: (key) => values.get(String(key)) ?? null,
+       setItem: (key, value) => values.set(String(key), String(value)),
+       removeItem: (key) => { calls.push(String(key)); values.delete(String(key)); }
+     };
+     await import('./js/data/local/pluginCodeStore.js');
+     console.log(JSON.stringify({ value: values.get('pluginCodeCache') ?? null, calls }));`
+    ],
+    { cwd: new URL("..", import.meta.url), encoding: "utf8" }
+  );
+  assert.deepEqual(
+    JSON.parse(legacyProbe.stdout.trim()),
+    {
+      value: null,
+      calls: ["pluginCodeCache"]
+    },
+    "legacy pluginCodeCache must be removed without being parsed or migrated"
+  );
+
+  const originalSetItem = globalThis.localStorage.setItem;
+  const writes = [];
+  globalThis.localStorage.setItem = (key, value) => {
+    writes.push([String(key), String(value)]);
+    return originalSetItem.call(globalThis.localStorage, key, value);
+  };
+  try {
+    const saveResult = PluginCodeStore.save("async-provider", "éé", {}, { maxBytes: 8 });
+    assert.equal(typeof saveResult.then, "function", "cache save must be asynchronous");
+    assert.equal(await saveResult, true);
+    const getResult = PluginCodeStore.get("async-provider");
+    assert.equal(typeof getResult.then, "function", "cache get must be asynchronous");
+    assert.equal((await getResult).code, "éé");
+    assert.deepEqual(writes, [], "plugin source code must never be persisted in localStorage");
+
+    await PluginCodeStore.clearAll();
+    await PluginCodeStore.save("old", "1234", {}, { maxBytes: 4 });
+    await PluginCodeStore.save("new", "5678", {}, { maxBytes: 4 });
+    assert.equal(await PluginCodeStore.get("old"), null, "LRU quota should evict the oldest entry");
+    assert.equal((await PluginCodeStore.get("new")).code, "5678");
+    assert.equal(
+      await PluginCodeStore.totalBytes(),
+      4,
+      "quota accounting should reflect evictions"
+    );
+
+    await PluginCodeStore.clearAll();
+    await PluginCodeStore.save("profile-one-old", "1111", {}, { profile: "1", maxBytes: 4 });
+    await PluginCodeStore.save("profile-one-new", "2222", {}, { profile: "1", maxBytes: 4 });
+    await PluginCodeStore.save("profile-two-old", "3333", {}, { profile: "2", maxBytes: 4 });
+    await PluginCodeStore.save("profile-two-new", "4444", {}, { profile: "2", maxBytes: 4 });
+    assert.equal(await PluginCodeStore.get("profile-one-old", "1"), null);
+    assert.equal((await PluginCodeStore.get("profile-one-new", "1")).code, "2222");
+    assert.equal(await PluginCodeStore.get("profile-two-old", "2"), null);
+    assert.equal((await PluginCodeStore.get("profile-two-new", "2")).code, "4444");
+    assert.equal(await PluginCodeStore.totalBytes("1"), 4);
+    assert.equal(await PluginCodeStore.totalBytes("2"), 4);
+
+    await PluginCodeStore.clearAll();
+    await PluginCodeStore.save("same-provider", "profile-one", {}, { profile: "1" });
+    await PluginCodeStore.save("same-provider", "profile-two", {}, { profile: "2" });
+    assert.equal((await PluginCodeStore.get("same-provider", "1")).code, "profile-one");
+    assert.equal((await PluginCodeStore.get("same-provider", "2")).code, "profile-two");
+    assert.equal(await PluginCodeStore.clearProfile("2"), true);
+    assert.equal(await PluginCodeStore.get("same-provider", "2"), null);
+    assert.equal((await PluginCodeStore.get("same-provider", "1")).code, "profile-one");
+    assert.equal(
+      await PluginCodeStore.clearProfile("1"),
+      false,
+      "primary profile cannot be cleared by profile deletion"
+    );
+  } finally {
+    globalThis.localStorage.setItem = originalSetItem;
+    await PluginCodeStore.clearAll();
+  }
+}
+
+async function testPluginCodeCacheFailureFallbacks() {
+  const runProbe = async (failure) => {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `globalThis.localStorage = { getItem: () => null, setItem() {}, removeItem() {} };
+         const database = {
+           objectStoreNames: { contains: () => true },
+           transaction() {
+             const transaction = { objectStore: () => ({ put() {}, get() {}, delete() {}, clear() {} }) };
+             queueMicrotask(() => transaction.onabort?.());
+             return transaction;
+           }
+         };
+         globalThis.indexedDB = {
+           open() {
+             const request = { result: ${failure === "transaction" ? "database" : "null"} };
+             queueMicrotask(() => request.${failure === "open" ? "onerror" : "onsuccess"}?.());
+             return request;
+           }
+         };
+         const warnings = [];
+         console.warn = (...args) => warnings.push(args.join(' '));
+         const { PluginCodeStore } = await import('./js/data/local/pluginCodeStore.js');
+         const saved = await PluginCodeStore.save('fallback-provider', 'fallback-code');
+         const entry = await PluginCodeStore.get('fallback-provider');
+         const removed = await PluginCodeStore.remove('fallback-provider');
+         const hidden = await PluginCodeStore.get('fallback-provider');
+         const cleared = await PluginCodeStore.clearAll();
+         console.log(JSON.stringify({ saved, code: entry?.code ?? null, removed, hidden, cleared, warnings: warnings.length }));`
+      ],
+      { cwd: new URL("..", import.meta.url), encoding: "utf8" }
+    );
+    return JSON.parse(stdout.trim().split("\n").at(-1));
+  };
+
+  const expected = {
+    saved: true,
+    code: "fallback-code",
+    removed: false,
+    hidden: null,
+    cleared: false,
+    warnings: 2
+  };
+  assert.deepEqual(
+    await runProbe("open"),
+    expected,
+    "open failure must use usable memory fallback and report unverified persistent cleanup"
+  );
+  assert.deepEqual(
+    await runProbe("transaction"),
+    expected,
+    "transaction failure must use usable memory fallback and report unverified persistent cleanup"
+  );
+}
+
+async function testPluginCodeCacheProfileBoundedEnumeration() {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `globalThis.localStorage = { getItem: () => null, setItem() {}, removeItem() {} };
+       globalThis.IDBKeyRange = {
+         bound: (lower, upper, lowerOpen = false, upperOpen = false) => ({ lower, upper, lowerOpen, upperOpen })
+       };
+       const records = new Map([
+         ['1:plugin_a', { key: '1:plugin_a', code: 'aa', bytes: 2, lastUsedAt: 1 }],
+         ['2:plugin_b', { key: '2:plugin_b', code: 'bbbb', bytes: 4, lastUsedAt: 2 }]
+       ]);
+       const ranges = [];
+       const visited = [];
+       const request = (result) => { const r = { result }; queueMicrotask(() => r.onsuccess?.()); return r; };
+       const store = {
+         get: (key) => request(records.get(key)),
+         put: (value) => { records.set(value.key, value); return request(value.key); },
+         delete: (key) => { records.delete(key); return request(undefined); },
+         clear: () => { records.clear(); return request(undefined); },
+         openCursor(range) {
+           ranges.push(range ?? null);
+           const keys = [...records.keys()].sort().filter((key) =>
+             !range || (key >= range.lower && key <= range.upper));
+           const r = {};
+           let index = 0;
+           const step = () => {
+             if (index >= keys.length) { r.result = null; r.onsuccess?.(); return; }
+             const key = keys[index++];
+             visited.push(key);
+             r.result = { key, value: records.get(key), continue: () => queueMicrotask(step) };
+             r.onsuccess?.();
+           };
+           queueMicrotask(step);
+           return r;
+         }
+       };
+       const database = {
+         objectStoreNames: { contains: () => true },
+         transaction() {
+           const tx = { objectStore: () => store };
+           setTimeout(() => tx.oncomplete?.(), 0);
+           return tx;
+         }
+       };
+       globalThis.indexedDB = { open() { const r = { result: database }; queueMicrotask(() => r.onsuccess?.()); return r; } };
+       const { PluginCodeStore } = await import('./js/data/local/pluginCodeStore.js');
+       const total = await PluginCodeStore.totalBytes('1');
+       const saved = await PluginCodeStore.save('extra', 'zz', {}, { profile: '1', maxBytes: 1024 });
+       const cleared = await PluginCodeStore.clear('1');
+       const remaining = [...records.keys()];
+       console.log(JSON.stringify({ total, saved, cleared, ranges, visited, remaining }));`
+    ],
+    { cwd: new URL("..", import.meta.url), encoding: "utf8" }
+  );
+  const result = JSON.parse(stdout.trim().split("\n").at(-1));
+  assert.equal(result.total, 2, "totalBytes must count only the effective profile");
+  assert.equal(result.saved, true);
+  assert.equal(result.cleared, true);
+  assert.equal(
+    result.ranges.length,
+    3,
+    "save, clear, and totalBytes each enumerate the profile once"
+  );
+  for (const range of result.ranges) {
+    assert.deepEqual(
+      range,
+      { lower: "1:", upper: "1:\uffff", lowerOpen: false, upperOpen: false },
+      "profile enumeration must use a prefix-bounded key range"
+    );
+  }
+  assert.equal(
+    result.visited.some((key) => key.startsWith("2:")),
+    false,
+    "another profile's records must never be visited"
+  );
+  assert.deepEqual(
+    result.remaining,
+    ["2:plugin_b"],
+    "clearing one profile must leave other profiles' persistent records intact"
+  );
+}
+
+async function testPluginManagerAwaitsCacheRemoval() {
+  const previousState = PluginStore.get();
+  const originalRemove = PluginCodeStore.remove;
+  let release;
+  let settled = false;
+  PluginStore.replace(
+    normalizePluginState({
+      repositories: [
+        {
+          id: "await-repository",
+          url: "https://example.com/repo",
+          type: PLUGIN_REPOSITORY_TYPES.NUVIO_JS
+        }
+      ],
+      scrapers: [
+        {
+          id: "await-provider",
+          repositoryId: "await-repository",
+          type: PLUGIN_REPOSITORY_TYPES.NUVIO_JS
+        }
+      ]
+    })
+  );
+  PluginCodeStore.remove = () =>
+    new Promise((resolve) => {
+      release = resolve;
+    });
+  try {
+    const removal = PluginManager.removeRepository("await-repository").then((value) => {
+      settled = true;
+      return value;
+    });
+    await Promise.resolve();
+    assert.equal(settled, false, "repository removal must await asynchronous cache deletion");
+    release(true);
+    assert.equal(await removal, true);
+  } finally {
+    PluginCodeStore.remove = originalRemove;
+    PluginStore.replace({ ...previousState, syncDirty: false });
+  }
+}
+
+async function testTypedRepositoryReconciliationAwaitsCleanup() {
+  const previousState = PluginStore.get();
+  const originalFetch = PluginServiceClient.fetch;
+  const originalRemove = PluginCodeStore.remove;
+  const releases = [];
+  let settled = false;
+  PluginStore.replace(
+    normalizePluginState({
+      repositories: [
+        {
+          id: "typed-dex-repository",
+          url: "https://example.com/typed-dex",
+          type: PLUGIN_REPOSITORY_TYPES.NUVIO_JS
+        },
+        {
+          id: "typed-legacy-repository",
+          url: "https://example.com/typed-legacy",
+          type: PLUGIN_REPOSITORY_TYPES.NUVIO_JS
+        }
+      ],
+      scrapers: [
+        {
+          id: "typed-dex-provider",
+          repositoryId: "typed-dex-repository",
+          type: PLUGIN_REPOSITORY_TYPES.NUVIO_JS
+        },
+        {
+          id: "typed-legacy-provider",
+          repositoryId: "typed-legacy-repository",
+          type: PLUGIN_REPOSITORY_TYPES.NUVIO_JS
+        }
+      ]
+    })
+  );
+  await PluginCodeStore.save("typed-dex-provider", "cached-code");
+  await PluginCodeStore.save("typed-legacy-provider", "cached-code");
+  PluginServiceClient.fetch = async () => ({
+    ok: true,
+    status: 200,
+    body: JSON.stringify({ plugins: [{ name: "External provider" }] }),
+    truncated: false
+  });
+  PluginCodeStore.remove = () => new Promise((resolve) => releases.push(resolve));
+  try {
+    const reconciliation = PluginManager.reconcileWithRemoteRepoUrls([
+      { url: "https://example.com/typed-dex", repoType: PLUGIN_REPOSITORY_TYPES.EXTERNAL_DEX },
+      { url: "https://example.com/typed-legacy", repoType: PLUGIN_REPOSITORY_TYPES.LEGACY }
+    ]).then((value) => {
+      settled = true;
+      return value;
+    });
+    for (let attempt = 0; attempt < 10 && releases.length < 2; attempt += 1) {
+      await Promise.resolve();
+    }
+    assert.equal(settled, false, "typed JS-to-DEX reconciliation must await cache cleanup");
+    assert.equal(releases.length, 1, "the first typed transition must await cache cleanup");
+    releases.shift()(true);
+    for (let attempt = 0; attempt < 10 && releases.length < 1; attempt += 1) {
+      await Promise.resolve();
+    }
+    assert.equal(releases.length, 1, "the second typed transition must await cache cleanup");
+    releases.shift()(true);
+    const reconciled = await reconciliation;
+    assert.equal(
+      reconciled.repositories.find((entry) => entry.id === "typed-dex-repository").type,
+      PLUGIN_REPOSITORY_TYPES.EXTERNAL_DEX
+    );
+    assert.equal(
+      reconciled.repositories.find((entry) => entry.id === "typed-legacy-repository").type,
+      PLUGIN_REPOSITORY_TYPES.LEGACY
+    );
+    assert.equal(reconciled.scrapers.length, 1, "DEX metadata should be reconciled after cleanup");
+  } finally {
+    PluginServiceClient.fetch = originalFetch;
+    PluginCodeStore.remove = originalRemove;
+    PluginStore.replace({ ...previousState, syncDirty: false });
   }
 }
 
@@ -630,7 +983,7 @@ async function testDexReconciliationSafety() {
   });
   try {
     PluginStore.replace(dexState);
-    assert.equal(PluginManager.removeRepository("dex-reconciliation"), false);
+    assert.equal(await PluginManager.removeRepository("dex-reconciliation"), false);
     assert.equal(PluginManager.setRepositoryEnabled("dex-reconciliation", false), false);
     assert.equal(PluginStore.get().repositories[0].enabled, true);
     // A partial/legacy cloud response contains another opaque row but omits
@@ -1431,6 +1784,11 @@ async function testWorkerRuntime() {
 async function main() {
   testModelsAndSecurity();
   await testRuntimeArtifactsAndContracts();
+  await testPluginCodeCacheContract();
+  await testPluginCodeCacheFailureFallbacks();
+  await testPluginCodeCacheProfileBoundedEnumeration();
+  await testPluginManagerAwaitsCacheRemoval();
+  await testTypedRepositoryReconciliationAwaitsCleanup();
   await testRawScraperTestContract();
   await testAndroidFetchResponseContract();
   await testPluginUiContract();


### PR DESCRIPTION
## Summary

Move the plugin source-code cache out of `localStorage` into a separate IndexedDB database with per-profile records, a bounded session-memory fallback, and one-time deletion of the legacy `pluginCodeCache` entry. Fixes the 1.0.2 responsiveness and storage-quota regression on LG webOS.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [x] Documentation
- [ ] Other

## Why

In 1.0.2 (`123ab8f`) `js/data/local/pluginCodeStore.js` stored all plugin source for a profile (8 to 16 MiB) as one JSON envelope in synchronous `localStorage` and rewrote the whole envelope on every `get` to touch the LRU timestamp. On webOS this exhausted the storage quota: the logs attached to the issue show repeated `localStorage.setItem('pluginCodeCache', ...)` quota failures followed by failures writing `pluginState` and `webos_last_resume_route`, and the synchronous multi-megabyte serialization on the main thread made every input feel slow. 1.0.1 did not have this cache.

Note for future changes: the root cause was the volume of synchronous `localStorage` writes on a TV browser. Any cache that grows with content (plugin code, catalogs, manifests) should go to IndexedDB, not `localStorage`.

## Issue or approval

Fixes #859

## Reproduction steps

1. Install 1.0.2 on an LG webOS TV and open the app.
2. Navigate the home screen and settings; input takes several seconds to respond.
3. Add a plugin repository; it stays on "Adding repository" for minutes and ends with 0 providers.
4. Inspect the console: `QuotaExceededError` on `pluginCodeCache`, then on `pluginState` and `webos_last_resume_route`.

## Old behavior

| | 1.0.2 |
|---|---|
| Where plugin code lives | one `localStorage` key `pluginCodeCache`, JSON envelope per profile |
| Size of that key | 8 to 16 MiB (quota cap in the store), on top of ~75 KB of other app state |
| Work per cache read | parse whole envelope, update one timestamp, re-serialize and rewrite whole envelope, synchronously |
| On quota failure | write swallowed, entry re-read to verify, subsequent unrelated `localStorage` writes fail |
| Repository import on webOS | minutes, then "0 providers" |

## New behavior

| | this PR |
|---|---|
| Where plugin code lives | IndexedDB database `nuvio_plugin_code_cache`, object store `code`, one record per `<profile>:<hashed cache key>` |
| `localStorage` | holds no plugin source; legacy `pluginCodeCache` removed once at startup with `removeItem`, never parsed |
| Work per cache read | one `get` plus one `put` on the single record, asynchronous |
| Quota / LRU | same byte cap, enforced per effective profile with a key-range-bounded cursor over that profile's records only |
| IndexedDB missing or failing | bounded session-memory fallback with the same cap; saves still succeed |
| Cleanup (repository removal, profile deletion, sign-out) | awaited; returns `false` and logs a warning when persistent deletion cannot be verified, records stay hidden for the session |
| Stale `codeAvailable: true` after the legacy cache is gone | code is re-downloaded at execution time |

Plugin state, repository metadata, settings and sync data stay in their existing `localStorage` stores.

## Platform impact

- Samsung Tizen: shared code path. Same async cache; not tested on Tizen hardware.
- LG webOS: the regressed platform. Fix deployed and exercised on a rooted LG TV, see Testing.
- Browser development mode: same code path; covered by the Node test suite with real and fake IndexedDB.
- Installer / packaging: no change. `npm run package:webos` output installed and launched.
- Wrapper repositories: no change.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only the plugin code cache backend moves. Plugin state, repository metadata, settings, sync payloads and every other `localStorage` store are unchanged.
- No dependency added. The IndexedDB open/transaction pattern is adapted from the existing `js/data/local/memberCatalogStorage.js`, not shared with it.
- No UI, playback, packaging, app-id or plugin security-policy change. `js/ui/screens/plugin/pluginsScreen.js` changes one line to await the now-async repository removal.
- The legacy `pluginCodeCache` payload is deleted, not migrated; plugin code is re-downloaded lazily.
- Diff is 7 files, +706/-152, of which +364 are tests in `scripts/test-plugin-system.mjs`.

## Testing

### Devices / platforms tested

- LG webOS TV (rooted, webOS 10.3.1 / Chromium WebAppMgr), app deployed from `npm run package:webos` output.
- Node 24 for the test suite (real `node:test` runs plus child-process probes with fake `indexedDB` / `IDBKeyRange`).
- Not tested on Samsung Tizen hardware.

### Commands tested

```sh
npx prettier --check js/data/local/pluginCodeStore.js js/core/player/pluginManager.js js/ui/screens/plugin/pluginsScreen.js js/core/profile/profileSelectionScreen.js js/core/auth/authManager.js scripts/test-plugin-system.mjs docs/plugin-runtime.md
npm run build
node ./scripts/test-plugin-system.mjs
npm test            # build + plugin system suite + localization suite (31 locales)
npm run package:webos
```

All pass. `npm test` prints `plugin system tests passed` and `plugin localization tests passed (31 locales)`.

New or extended tests in `scripts/test-plugin-system.mjs`:
- fresh-process probe: legacy `pluginCodeCache` is removed without being read
- `localStorage.setItem` spy: zero writes of plugin code
- async save/get, LRU eviction, per-profile quota isolation, `clearProfile`
- IndexedDB open failure and transaction abort: save and get still succeed in memory, `remove`/`clearAll` return `false` with a warning
- fake IndexedDB recording every `openCursor` range: profile enumeration is bounded to `"<profile>:"` … `"<profile>:￿"` and never visits another profile's records
- `removeRepository` and typed JS→DEX/legacy reconciliation wait for cache deletion

## Manual test flow

On the LG TV after deploying the build and launching the app, inspected through the DevTools protocol:
- `localStorage.getItem("pluginCodeCache")` is `null` after the first launch (legacy key removed).
- All 38 existing `localStorage` keys, including `pluginState`, profiles and tokens, are intact; total `localStorage` payload is ~77 KB.
- No `QuotaExceededError` or plugin-cache warnings in the console across two launches and one reload.
- Reported by the tester on that TV: the app is noticeably more fluid than the 1.0.2 build it replaced. Not measured, subjective.

Not exercised by me on the device: adding a plugin repository end to end (this TV had no repositories configured). That path is covered by the Node suite with real repository fixtures and fake IndexedDB, and is the main thing to re-check on webOS before release.

## Screenshots / Video

Not a UI change.

## Logs

Issue #859 attachment: repeated `localStorage.setItem('pluginCodeCache', ...)` quota failures followed by `pluginState` and `webos_last_resume_route` write failures. After this change the TV console shows no storage errors.

## Regression risk

- Every caller of the cache now awaits it: `js/core/player/pluginManager.js` (hydrate, execute, repository removal, typed reconciliation, `clearCache`), `js/core/auth/authManager.js` sign-out, `js/core/profile/profileSelectionScreen.js` profile deletion, `js/ui/screens/plugin/pluginsScreen.js` repository removal. The suite asserts the awaits for repository removal and reconciliation.
- Cleanup can now return `false`; all callers ignore the return value and only log, so sign-out, profile deletion and repository removal still complete.
- Tizen runs the same shared code. Tizen's Chromium has IndexedDB; if it is unavailable or fails, the memory fallback keeps plugins working for the session with the same quota. Not verified on Tizen hardware.
- After one transient IndexedDB failure the session stays memory-only until the app is relaunched. Deliberate.
- Users upgrading from 1.0.2 lose the cached plugin code once and re-download it lazily on first use.

## Breaking changes

None. `localStorage` key `pluginCodeCache` is removed on upgrade; it held disposable cache data only.

## Linked issues

Fixes #859
