### PR TITLE
fix(subtitles): avoid false VTT fallback and ensure ASS playback kick on webOS

### DIFF
--- a/js/core/player/assRenderer.js
+++ b/js/core/player/assRenderer.js
@@ -36,16 +36,6 @@ function debugAssRender(stage, details = {}) {
   }
 }
 
-function hasRawAssControlText(container) {
-  const text = String(container?.textContent || "");
-  return (
-    // Require the SSA field shape so legitimate cue text that merely starts
-    /(?:^|\n)\s*(?:Dialogue|Comment)\s*:\s*(?:\d+|Marked\s*=\s*\d+)\s*,\s*\d+:\d{1,2}:\d{1,2}[.,]/i.test(
-      text
-    ) || /(?:^|\n)\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(text)
-  );
-}
-
 export function createAssRenderer({
   body,
   video,
@@ -152,16 +142,6 @@ export function createAssRenderer({
           childCount: Number(container.childNodes?.length || 0),
           text: String(container.textContent || "").slice(0, 240)
         });
-        if (hasRawAssControlText(container)) {
-          instance.destroy?.();
-          instance = null;
-          clearContainer(container);
-          return {
-            ok: false,
-            error: "ass-renderer-raw-control-text",
-            detail: "ass.js exposed ASS control fields as visible text"
-          };
-        }
         // ass.js starts its frame loop only on a play/playing event. When a
         // subtitle is selected mid-playback the video is already playing, so
         // those events fired before this instance existed and the renderer

--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -14218,11 +14218,10 @@ export const PlayerScreen = {
       // not fire it; make ass.js capture requestAnimationFrame instead.
       forceRafFrameLoop: Environment.isWebOS(),
       // The webOS native pipeline can leave video.paused=true while the app
-      // is playing. Kick the newly-created renderer only when the controller
-      // and player UI both still consider playback active, so a paused
-      // selection does not start an uncancellable frame loop.
-      forcePlaybackFrameLoopKick:
-        Environment.isWebOS() && PlayerController.isPlaying && !this.paused
+      // is playing. Trust the controller's playing state here: the player UI
+      // paused flag can lag transient playback states, and a missed kick
+      // leaves ass.js frozen on its initial cue.
+      forcePlaybackFrameLoopKick: Environment.isWebOS() && PlayerController.isPlaying
     });
     if (!renderer || typeof renderer.init !== "function") {
       return { applied: false, fallbackVtt: convertAssBodyToVtt(body) };


### PR DESCRIPTION
## Summary

- Remove unsafe post-render text inspection (`hasRawAssControlText`) in `assRenderer.js` that was tearing down `ass.js` instances and falsely demoting legitimate ASS subtitles to plain VTT when rendered cues matched control patterns.
- Ensure the playback frame loop kick (`forcePlaybackFrameLoopKick`) in `playerScreen.js` relies strictly on `PlayerController.isPlaying` instead of gating on UI `!this.paused`, preventing intermittent ASS freezes on webOS where native `video.paused=true` while playback is active.

## PR type

- [x] Critical bug fix

## Affected area

- [x] Shared web app
- [x] LG webOS
- [x] Playback
- [x] Subtitles

## Why

1. When subtitle cues legitimately contain text that triggered the overly broad post-render check, `ass.js` was destroyed immediately after construction, forcing a VTT fallback that lost positioning, styles, and stacking.
2. On webOS, `this.paused` in player UI can lag transient playback states (startup, seeks, buffering), causing `forcePlaybackFrameLoopKick` to stay false even though `PlayerController.isPlaying` is true and webOS native video reports `paused=true`. As a result, the synthetic `play` event was not dispatched, causing the subtitle renderer to paint once and freeze.

## Issue or approval

Fixes intermittent ASS subtitle freeze and style loss during playback.

## Reproduction steps

1. Play a video with ASS subtitles (embedded or external) on webOS or with cues that trigger post-render regex checks.
2. Observe subtitles either dropping styles/layering due to unexpected VTT demotion or rendering the initial cue and freezing without advancing.

## Old behavior

- `hasRawAssControlText` checked `container.textContent` post-construction and destroyed the ASS instance on false positives, dumping fallback VTT cues.
- `forcePlaybackFrameLoopKick` was gated behind `!this.paused`, missing the play kick when UI state lagged during playback startup/seek.

## New behavior

- `ass.js` instance is preserved without post-render DOM text demotion.
- Playback frame loop kick is guaranteed when `PlayerController.isPlaying` is active on webOS.

## Platform impact

- Samsung Tizen: Preserves ASS instance without false VTT demotion.
- LG webOS: Fixes frame loop kick and prevents cue freeze mid-playback.
- Browser development mode: Consistent ASS lifecycle.

## UI / behavior / playback impact

- [x] Playback changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only touches `js/core/player/assRenderer.js` and `js/ui/screens/player/playerScreen.js`. No changes to parsing or unrelated player UI logic.

## Testing

### Commands tested

```sh
node --check js/core/player/assRenderer.js
node --check js/ui/screens/player/playerScreen.js
git diff --check
npx prettier --check js/core/player/assRenderer.js js/ui/screens/player/playerScreen.js
```

## Regression risk

Minimal. `PlayerController.isPlaying` correctly reflects active playback across webOS pipelines, and `assRenderer.js` still retains internal safety fallbacks.
