### PR TITLE
fix(subtitles): parse short ASS event headers and suppress drawing dumps

### DIFF
--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -142,11 +142,21 @@ function formatVttTimestamp(totalSeconds) {
 }
 
 function sanitizeAssDialogueText(text) {
-  return String(text || "")
-    .replace(/\\[Nn]/g, "\n")
-    .replace(/\\h/g, " ")
-    .replace(/\{[^}]*\}/g, "")
-    .trim();
+  return (
+    String(text || "")
+      .replace(/\\[Nn]/g, "\n")
+      .replace(/\\h/g, " ")
+      // Vector drawings (\\p1...\\p0) carry no readable dialogue: remove the
+      // whole drawing section so path data never becomes cue text. A drawing
+      // without \\p0 runs to the end of the event by spec.
+      .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
+      .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "")
+      .replace(/\{[^}]*\}/g, "")
+      // A truncated final override block (no closing brace) is tag source,
+      // not dialogue.
+      .replace(/\{[^\n}]*$/gm, "")
+      .trim()
+  );
 }
 
 const ASS_POSITION_RE = /\\pos\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)/i;

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1051,15 +1051,51 @@ function parseAssTimestampMs(value) {
   );
 }
 
-function textAfterCommaCount(value, commaCount) {
-  var text = String(value || "");
-  var offset = 0;
-  for (var index = 0; index < commaCount; index += 1) {
-    var comma = text.indexOf(",", offset);
-    if (comma < 0) return "";
-    offset = comma + 1;
+function hasBalancedAssBraces(text) {
+  var value = String(text || "");
+  return value.split("{").length === value.split("}").length;
+}
+
+// ASS event rows do not always carry the full 10-field header: stripped or
+// remuxed events can omit Style/Name/Margins/Effect. A fixed comma count
+// then slices mid-override-block, projecting fragments like
+// "320,820)\\frz358.4..." as visible text (or dropping the cue when commas
+// run out). Walk the split point down until the Text candidate has balanced
+// braces; otherwise preserve the historical fixed-count extraction verbatim.
+function splitAssEventFields(assEvent, firstTry, floor, fallbackTry) {
+  var segments = String(assEvent || "").split(",");
+  var fallback = {
+    header: segments.slice(0, fallbackTry),
+    text: segments.slice(fallbackTry).join(",")
+  };
+  var top = Math.min(firstTry, segments.length - 1);
+  if (top === firstTry) {
+    var direct = segments.slice(firstTry).join(",");
+    if (!direct) {
+      return fallback;
+    }
+    if (hasBalancedAssBraces(direct)) {
+      return { header: segments.slice(0, firstTry), text: direct };
+    }
+    top = firstTry - 1;
   }
-  return text.slice(offset);
+  for (var splitAt = top; splitAt >= floor; splitAt--) {
+    var text = segments.slice(splitAt).join(",");
+    if (text && hasBalancedAssBraces(text)) {
+      return { header: segments.slice(0, splitAt), text: text };
+    }
+  }
+  return fallback;
+}
+
+// Vector drawings (\\p1...\\p0) and truncated override blocks carry no
+// readable dialogue. Plain-text pipelines (VTT/HTML/native) must not project
+// them as cue text; the ASS body path keeps the original payload for ass.js.
+function sanitizePlainTextAssCue(text) {
+  return String(text || "")
+    .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
+    .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "")
+    .replace(/\{[^\n}]*$/gm, "");
 }
 
 function decodeTextSubtitlePayload(payload) {
@@ -1117,11 +1153,11 @@ function normalizeTextSubtitlePayload(track, payload) {
     /^-?\d+$/.test(String(fields[0] || "").trim()) &&
     /^-?\d+$/.test(String(fields[1] || "").trim());
   if (hasLayeredAssTiming) {
-    text = textAfterCommaCount(assEvent, 9) || "";
+    text = splitAssEventFields(assEvent, 9, 3, 9).text;
   } else if (hasShortAssTiming) {
-    text = textAfterCommaCount(assEvent, fields.length >= 9 ? 8 : 2) || "";
+    text = splitAssEventFields(assEvent, 8, 2, fields.length >= 9 ? 8 : 2).text;
   } else if (hasPositionalAssShape) {
-    text = textAfterCommaCount(assEvent, 8) || "";
+    text = splitAssEventFields(assEvent, 8, 3, 8).text;
   } else if (isAssTextSubtitleTrack(track)) {
     text = assEvent;
   }
@@ -1253,7 +1289,7 @@ function getAssDialogueText(track, frame) {
   var event = raw.replace(/^\s*Dialogue\s*:\s*/i, "");
   var fields = event.split(",");
   if (fields.length >= 10 && isAssTimestamp(fields[1]) && isAssTimestamp(fields[2])) {
-    return fields.slice(9).join(",").trim();
+    return splitAssEventFields(event, 9, 3, 9).text.trim();
   }
   if (
     fields.length >= 9 &&
@@ -1261,7 +1297,7 @@ function getAssDialogueText(track, frame) {
     isAssTimestamp(fields[1]) &&
     isAssTextSubtitleTrack(track)
   ) {
-    return fields.slice(8).join(",").trim();
+    return splitAssEventFields(event, 8, 2, 8).text.trim();
   }
   return normalizeTextSubtitlePayload(track, frame && frame.payload);
 }
@@ -1276,9 +1312,14 @@ function buildAssDialogueLine(track, frame, nextFrame) {
   var event = raw.replace(/^\s*Dialogue\s*:\s*/i, "");
   var fields = event.split(",");
   if (fields.length >= 10 && isAssTimestamp(fields[1]) && isAssTimestamp(fields[2])) {
-    fields[1] = formatAssTimestamp(startMs);
-    fields[2] = formatAssTimestamp(endMs);
-    return "Dialogue: " + fields.slice(0, 9).concat(fields.slice(9).join(",")).join(",");
+    var split = splitAssEventFields(event, 9, 3, 9);
+    var header = split.header.slice();
+    while (header.length < 9) {
+      header.push("");
+    }
+    header[1] = formatAssTimestamp(startMs);
+    header[2] = formatAssTimestamp(endMs);
+    return "Dialogue: " + header.slice(0, 9).concat(split.text).join(",");
   }
   // Preserve leading ASS fields only for the two shapes that carry them.
   // Metadata alone is not enough: webOS can expose ordinary cue text as a
@@ -1627,7 +1668,11 @@ function buildTextSubtitleWindowPayload(track, frames, startMs, endMs, options) 
   var hasOverrides = false;
   var hasAdvancedOverrides = false;
   frames.forEach(function (frame, index) {
-    var text = normalizeTextSubtitlePayload(track, frame.payload);
+    var rawText = normalizeTextSubtitlePayload(track, frame.payload);
+    if (!rawText) return;
+    // Strip drawings/truncated tags for the readable-text body only; the
+    // ASS body below keeps the original payload for ass.js.
+    var text = sanitizePlainTextAssCue(rawText);
     if (!text) return;
     var cueStartMs = Number(frame.timestampMs);
     var cueEndMs = getTextCueEndMs(frame, frames[index + 1]);
@@ -1648,8 +1693,8 @@ function buildTextSubtitleWindowPayload(track, frames, startMs, endMs, options) 
     }
     outputBytes += blockBytes;
     cueBlocks.push(block);
-    hasOverrides = hasOverrides || hasAssOverrideTags(text);
-    hasAdvancedOverrides = hasAdvancedOverrides || hasAdvancedAssOverrideTags(text);
+    hasOverrides = hasOverrides || hasAssOverrideTags(rawText);
+    hasAdvancedOverrides = hasAdvancedOverrides || hasAdvancedAssOverrideTags(rawText);
   });
   var body = "WEBVTT\n\n" + (cueBlocks.length ? cueBlocks.join("\n\n") + "\n\n" : "");
   var includeAssBody =


### PR DESCRIPTION
## Summary

- Fix fixed-comma-count ASS event parsing in `services/webos/src/bitmapSubtitles.js`: events with short headers (missing Style/Name/Margins/Effect) were sliced mid-override-block, projecting fragments like `320,820)\frz358.4\org(...)...` as visible text, or dropping cues entirely when commas ran out.
- Suppress ASS vector-drawing (`\p1...\p0`) path data and truncated override blocks in all plain-text pipelines (VTT/HTML/native fallback), so drawings no longer render as walls of coordinates. The ASS body keeps the original payload untouched for ass.js.

## PR type

- [x] Critical bug fix

## Affected area

- [x] Shared web app
- [x] LG webOS
- [x] Playback
- [x] Subtitles

## Why

Photos from 1.0.5 show two symptoms on typeset anime subtitles (JoJo S1, JJK):

1. Raw override internals on screen (`...\frz358.4\org(1889.15,82.92)\c&H1B1516&}Menacing`, `...)\fsp0.0` + dialogue). Reproduced: `normalizeTextSubtitlePayload` assumed the full 10-field layout (`textAfterCommaCount(assEvent, 9)`) for any event with Layer + timestamps. An event missing the Effect field returns `320,820,640)\frz358.4\org(1889.15,82.92)\c&H1B1516&}Menacing` — a mid-tag fragment with no opening brace, rendered literally by every downstream renderer.
2. Full-screen walls of coordinate pairs (`64.89 68.77 64.17 ... m 88.22 ...`). Reproduced: `sanitizeAssDialogueText` stripped the `{\p1}`/`{\p0}` wrappers but left drawing path data, so `convertAssBodyToVtt` emitted `m 64.89 68.77 l 64.17 ...` as cue text.
3. Missing dialogue ("nothing appears when they are speaking"): stripped events (`Dialogue: 0,start,end,{\an8}Hello`) yielded `""` and the cue was dropped.

Note: the 1.0.4..1.0.5 window contains no subtitle-pipeline changes (verified via diff); these code paths are identical in 1.0.4. The defect is input-dependent (nonstandard/stripped event headers from remuxed or heavy-typeset files) and reproduces on 1.0.4 code. 

## Issue or approval

Fixes raw ASS internals projected as subtitle text and silently dropped dialogue cues.

## Reproduction steps

1. Play content with embedded ASS using short event headers (e.g. missing Effect field) or `\p` drawing cues on webOS.
2. Observe override fragments / coordinate walls on screen, or missing lines during speech.

Node repro (service): `normalizeTextSubtitlePayload` on `Dialogue: 0,0:00:12.00,0:00:14.00,Default,,0,0,0,{\an5\move(-4009,320,820,640)\frz358.4\org(1889.15,82.92)\c&H1B1516&}Menacing` returned the mid-tag fragment before this fix, full text after.
Node repro (app): `convertAssDialogueToVttCues` on a `{\p1}m 64.89 68.77 l ...{\p0}` event emitted the path data as cue text before this fix, no cue after.

## Old behavior

- Short-header events produced override fragments as visible text in both the VTT body and the ASS body.
- Drawing-only cues produced coordinate-dump text cues in VTT/HTML/native fallbacks.
- Stripped events produced empty text and were silently dropped.

## New behavior

- `splitAssEventFields` walks the header/text split down until the Text candidate has balanced braces; well-formed events take the exact historical split (verified byte-identical outputs), malformed ones recover the true text, and anything else falls back to the historical extraction verbatim.
- `buildAssDialogueLine` rebuilds short headers padded to 9 fields, so the ASS body parses correctly in ass.js.
- Plain-text outputs drop drawing sections and truncated override blocks; override detection flags still use the raw text.

## Platform impact

- Samsung Tizen: no change for well-formed events; malformed events now yield readable text instead of fragments.
- LG webOS: same as above, via the companion text-subtitle window payloads.
- Browser development mode: same converter behavior for external ASS fallback.
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `services/webos/src/bitmapSubtitles.js` (event splitting + plain-text sanitizing) and `js/core/player/assSubtitle.js` (`sanitizeAssDialogueText`). No renderer lifecycle, detection, or selection changes. ass.js input (ASS body) keeps full payloads including drawings.

## Testing

### Commands tested

```sh
node --check services/webos/src/bitmapSubtitles.js
node --check js/core/player/assSubtitle.js
git diff --check
npx prettier --check services/webos/src/bitmapSubtitles.js js/core/player/assSubtitle.js
```

### Behavioral checks (node)

- Well-formed 10-field / short-SSA / positional / control-row / empty-text / non-ASS CSV cases: outputs byte-identical to pre-fix behavior.
- `missingEffect` event: fragment before, full `{\an5\move...}Menacing` after.
- Stripped `Dialogue: 0,start,end,{\an8}Hello` / `Hello`: recovered (previously `""`).
- Legit unbalanced text (`a}b`): preserved via historical fallback.
- `buildTextSubtitleWindowPayload`: VTT body carries full text, drawing cue absent; ASS body rebuilt with padded header + full text, drawing event intact for ass.js.
- `convertAssDialogueToVttCues`: drawing-only event yields no cue; truncated tail cut; plain CSV and normal lines intact.

## Manual test flow

Not tested on TV hardware in this session; verification is via the service/app-level repros above. Needs on-device confirmation on webOS with the photographed episodes.

## Screenshots / Video

Reporter photos show the before state (override fragments, coordinate walls). No new UI.

## Logs

Not applicable.

## Regression risk

Low. Well-formed events follow the identical code path as before (asserted byte-identical). Changed behavior is confined to inputs that previously produced visible garbage or dropped cues. Residual ambiguity only for structurally ambiguous short headers, where showing the most plausible text beats fragments/emptiness.

## Breaking changes

None.
