### PR TITLE
fix(subtitles): claim app subtitle ownership before native hide on webOS

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -10862,6 +10862,12 @@ export const PlayerScreen = {
         if (this.selectedEmbeddedSubtitleTrackIndex !== selectedIndex) {
           return;
         }
+        // Re-check ownership at fire time, not just at schedule time: an
+        // ASS/HTML takeover may have completed during these 50ms, and its
+        // native hide must not be undone by a stale re-enable.
+        if (this.webOsEmbeddedTextSubtitleUsingAss || this.webOsEmbeddedTextSubtitleUsingHtml) {
+          return;
+        }
         PlayerController.setWebOsEmbeddedSubtitleTrack(targetTrackIndex, selectedIndex);
       }, 50);
       this.embeddedSubtitleCueRefreshTimers.add(timerId);
@@ -16317,6 +16323,13 @@ export const PlayerScreen = {
             this.destroyAssSubtitleRenderer();
             return false;
           }
+          // Claim app ownership BEFORE awaiting the native hide: the hide is
+          // an async Luna round trip, and any refresh racing it must already
+          // see that the native renderer has to stay off. Otherwise a delayed
+          // enable lands after the hide and both renderers stay visible.
+          const wasUsingHtml = this.webOsEmbeddedTextSubtitleUsingHtml;
+          this.webOsEmbeddedTextSubtitleUsingAss = true;
+          this.webOsEmbeddedTextSubtitleUsingHtml = false;
           const nativeRendererHidden = await Promise.resolve(
             PlayerController.setWebOsEmbeddedSubtitleNativeVisibility(
               false,
@@ -16324,12 +16337,12 @@ export const PlayerScreen = {
             )
           );
           if (!nativeRendererHidden) {
+            this.webOsEmbeddedTextSubtitleUsingAss = false;
+            this.webOsEmbeddedTextSubtitleUsingHtml = wasUsingHtml;
             this.destroyAssSubtitleRenderer();
             return false;
           }
           this.clearHtmlSubtitleOverlay();
-          this.webOsEmbeddedTextSubtitleUsingAss = true;
-          this.webOsEmbeddedTextSubtitleUsingHtml = false;
           return true;
         }
         if (assResult.fallbackVtt) {
@@ -16357,6 +16370,9 @@ export const PlayerScreen = {
       }
 
       if (!this.webOsEmbeddedTextSubtitleUsingHtml) {
+        // Same ownership claim as the ASS branch above: never let a native
+        // enable slip in while the hide round trip is in flight.
+        this.webOsEmbeddedTextSubtitleUsingHtml = true;
         const nativeRendererHidden = isTizenEmbeddedTextSubtitleFallbackTrack(track)
           ? Boolean(PlayerController.applyAvPlaySubtitleRenderMode?.("html"))
           : typeof PlayerController.setWebOsEmbeddedSubtitleNativeVisibility === "function"
@@ -16372,9 +16388,9 @@ export const PlayerScreen = {
           this.webOsEmbeddedTextSubtitleTrack !== track ||
           !nativeRendererHidden
         ) {
+          this.webOsEmbeddedTextSubtitleUsingHtml = false;
           return false;
         }
-        this.webOsEmbeddedTextSubtitleUsingHtml = true;
       }
 
       this.htmlSubtitleCues = cues;


### PR DESCRIPTION
## Summary

- Fix a race where the webOS native subtitle renderer is re-enabled on top of the app renderer, producing duplicated subtitles (styled ASS + plain native copy visible at once).
- Claim `webOsEmbeddedTextSubtitleUsingAss` / `webOsEmbeddedTextSubtitleUsingHtml` BEFORE awaiting the async native-hide Luna round trip (restoring the previous value if the hide fails), instead of after it.
- Re-check those flags at fire time in the debounced 50ms `setWebOsEmbeddedSubtitleTrack` re-enable, not just at schedule time.

## PR type

- [x] Critical bug fix

## Affected area

- [x] Shared web app
- [x] LG webOS
- [x] Playback
- [x] Subtitles

## Why

Reported on 1.0.6 with internal ASS tracks: the same line renders twice (positioned/styled ASS copy plus a plain copy), alongside raw override blocks drawn by the platform renderer.

Trace of the race:

1. Track selection sends native `setSubtitleEnable: { enable: true }`.
2. The ASS/HTML takeover sends `setSubtitleEnable: { enable: false }`, but the ownership flags were only set AFTER that async round trip resolved.
3. Any refresh scheduled in between (style/cue refresh, or the debounced 50ms native re-select, which only validated the track index at fire time) lands a second `enable: true` AFTER the hide.
4. End state: native renderer back on while ass.js/HTML also renders. Every subsequent window repeats the pattern, so the duplication looks intermittent ("sometimes").

## Issue or approval

Fixes duplicated embedded subtitles (app + native copies visible simultaneously) on webOS.

## Reproduction steps

1. Play content with internal ASS subtitles on webOS.
2. Trigger cue/style refreshes or window reloads (seeks, style changes, long playback across extraction windows).
3. Observe the same line rendered twice: once positioned/styled, once plain.

## Old behavior

- Ownership flags were set after the hide round trip; a racing native re-enable in between stayed effective permanently (until the next window).
- The 50ms re-enable timer never re-validated ownership at fire time.

## New behavior

- Ownership is claimed before the hide await; concurrent refreshes already observe it and stand down.
- The 50ms timer re-checks ownership at fire time and skips the re-enable when the app owns rendering.
- On hide failure the previous flag values are restored exactly, preserving the historical fallback behavior.

## Platform impact

- Samsung Tizen: the HTML branch keeps its AVPlay render-mode path unchanged; only flag timing around it changed.
- LG webOS: native stays hidden once the app takes over embedded subtitles.
- Browser development mode: no native pipeline; code paths unaffected (`setWebOsEmbeddedSubtitleNativeVisibility` is webOS-gated).
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `js/ui/screens/player/playerScreen.js` (3 hunks, +19/-3). No parser, renderer-lifecycle, detection, or veto changes. No ASS/service payload changes.

## Testing

### Commands tested

```sh
node --check js/ui/screens/player/playerScreen.js
git diff --check
npx prettier --check js/ui/screens/player/playerScreen.js
```

## Manual test flow

Not tested on TV hardware in this session. Needs on-device confirmation with internal ASS content: styled and plain copies must never co-exist after takeover, across seeks and window reloads.

## Screenshots / Video

Reporter photos show the before state (duplicated styled + plain lines, raw platform-rendered override blocks).

## Logs

Not applicable.

## Regression risk

Low. Success-path end state is identical (same flags, same hide call, same order of Luna commands on the wire for the non-racing case). Failure paths restore previous flag values exactly. The only behavior change is suppressing a native re-enable that used to undo an in-flight hide.

## Breaking changes

None.
