### PR TITLE
fix(subtitles): suppress ASS tag residue in plain-text fallback

### DIFF
--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -142,11 +142,19 @@ function formatVttTimestamp(totalSeconds) {
 }
 
 function sanitizeAssDialogueText(text) {
-  return String(text || "")
-    .replace(/\\[Nn]/g, "\n")
-    .replace(/\\h/g, " ")
-    .replace(/\{[^}]*\}/g, "")
-    .trim();
+  return (
+    String(text || "")
+      .replace(/\\[Nn]/g, "\n")
+      .replace(/\\h/g, " ")
+      // Vector drawings (\\p1...\\p0) carry no readable dialogue. Remove
+      // closed drawing sections only, mirroring ass.js semantics (text after
+      // an unclosed \\p block is drawing data up to the event end, never
+      // dialogue). All other override blocks keep the historical handling.
+      .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
+      .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "")
+      .replace(/\{[^}]*\}/g, "")
+      .trim()
+  );
 }
 
 const ASS_POSITION_RE = /\\pos\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)/i;

--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -176,6 +176,10 @@ function sanitizeAssDialogueText(text) {
     String(text || "")
       .replace(/\\[Nn]/g, "\n")
       .replace(/\\h/g, " ")
+      // An orphan override block fragment (e.g. `11.12,955.26)\fsp0.01}`)
+      // sliced mid-tag before `{`: drop the tag residue up to `}` so the
+      // readable dialogue following it is rescued.
+      .replace(/^[^{}\n]*\\[^{}\n]*\}/, "")
       // Vector drawings (\\p1...\\p0) carry no readable dialogue. Remove
       // closed drawing sections only, mirroring ass.js semantics (text after
       // an unclosed \\p block is drawing data up to the event end, never

--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -152,7 +152,8 @@ function hasUnbalancedAssMarkup(value) {
   return text.split("{").length !== text.split("}").length;
 }
 
-const ASS_TAG_SOUP_RE = /\\[A-Za-z]+[(\&]/;
+const ASS_TAG_SOUP_RE =
+  /\\[A-Za-z]+[(\&]|\\(?:pos|move|org|clip|iclip|fad|fade|t)\s*\(|\\(?:[1-4]?c|alpha|[1-4]?a)&|\\(?:an[1-9]|fsp[-+]?\d|fs\d|fr[xyz]?[-+]?\d|x?bord\d|x?shad\d|blur\d|be\d|q[0-3]|pbo[-+]?\d)(?=[^A-Za-z]|$)/i;
 
 // Detects override-tag residue that survived block stripping: a backslash
 // command with unbalanced braces (cut block), or a backslash command opening

--- a/js/core/player/assSubtitle.js
+++ b/js/core/player/assSubtitle.js
@@ -141,6 +141,36 @@ function formatVttTimestamp(totalSeconds) {
   return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}.${pad(milliseconds, 3)}`;
 }
 
+// Strips literal backslash escapes that collide with brace accounting before
+// inspecting markup residue.
+function stripAssTextEscapes(value) {
+  return String(value || "").replace(/\\\\|\\[NnHh]/g, "");
+}
+
+function hasUnbalancedAssMarkup(value) {
+  const text = String(value || "");
+  return text.split("{").length !== text.split("}").length;
+}
+
+const ASS_TAG_SOUP_RE = /\\[A-Za-z]+[(\&]/;
+
+// Detects override-tag residue that survived block stripping: a backslash
+// command with unbalanced braces (cut block), or a backslash command opening
+// `(` or `&` with no block at all (braceless fragment). Ordinary dialogue —
+// including backslash paths like `C:\path (x86)` or `a}b`-style braces —
+// does not match and is preserved. Never guesses where Text starts, so it
+// cannot truncate legitimate dialogue.
+function looksLikeAssTagSoup(text) {
+  const value = stripAssTextEscapes(text);
+  if (value.indexOf("\\") < 0) {
+    return false;
+  }
+  if (hasUnbalancedAssMarkup(value)) {
+    return true;
+  }
+  return ASS_TAG_SOUP_RE.test(value);
+}
+
 function sanitizeAssDialogueText(text) {
   return (
     String(text || "")
@@ -153,6 +183,9 @@ function sanitizeAssDialogueText(text) {
       .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
       .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "")
       .replace(/\{[^}]*\}/g, "")
+      // A truncated final override block (no closing brace) is tag source,
+      // not dialogue.
+      .replace(/\{[^\n}]*$/gm, "")
       .trim()
   );
 }
@@ -479,6 +512,11 @@ export function convertAssDialogueToVttCues(body) {
     const end = parseAssTimestamp(record.end);
     const text = sanitizeAssDialogueText(record.text);
     if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start || !text) {
+      return;
+    }
+    // Tag-soup residue is not dialogue in any renderer: drop the cue instead
+    // of projecting override source as visible text.
+    if (looksLikeAssTagSoup(text)) {
       return;
     }
     const rawText = String(record.text || "");

--- a/scripts/test-ass-drawing-fallback.mjs
+++ b/scripts/test-ass-drawing-fallback.mjs
@@ -1,0 +1,123 @@
+// Focused regression tests: ASS vector drawings must never surface as
+// readable cue text in plain-text pipelines (VTT/HTML/native fallback).
+// Run: node ./scripts/test-ass-drawing-fallback.mjs
+// A drawing section carries no dialogue by ASS semantics (ass.js renders it
+// as a vector shape with empty text, and text after an unclosed \p block is
+// drawing data up to the event end), so suppressing it cannot truncate
+// legitimate dialogue. Covered units:
+// - js/core/player/assSubtitle.js (external-file VTT fallback)
+// - services/webos/src/bitmapSubtitles.js (embedded VTT window body; the ASS
+//   body must keep the original payload so ass.js still draws the shapes).
+
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const { convertAssDialogueToVttCues } = await import(
+  path.join(rootDir, "js/core/player/assSubtitle.js")
+);
+const service = require(path.join(rootDir, "services/webos/src/bitmapSubtitles.js"))._test;
+
+let failures = 0;
+
+function check(name, actual, expected) {
+  const ok = actual === expected;
+  if (!ok) {
+    failures += 1;
+  }
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}`);
+  if (!ok) {
+    console.log(`  expected: ${JSON.stringify(expected)}`);
+    console.log(`  actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+function vttCueTexts(body) {
+  return convertAssDialogueToVttCues(body).map((cue) => cue.text);
+}
+
+function assBody(textLines) {
+  return [
+    "[Script Info]",
+    "Title: t",
+    "[V4+ Styles]",
+    "[Events]",
+    "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
+    ...textLines.map(
+      (text, index) =>
+        `Dialogue: 0,0:00:${String(10 + index).padStart(2, "0")}.00,0:00:${String(11 + index).padStart(2, "0")}.00,Default,,0,0,0,,${text}`
+    )
+  ].join("\n");
+}
+
+// --- App converter: drawing-only cues produce no cue. ---
+check(
+  "drawing-only event yields no cue",
+  JSON.stringify(vttCueTexts(assBody(["{\\p1}m 64.89 68.77 l 64.17 67.11 l 63.09 66.4{\\p0}"]))),
+  JSON.stringify([])
+);
+
+// --- App converter: dialogue adjacent to drawings is preserved. ---
+check(
+  "dialogue after closed drawing is preserved",
+  JSON.stringify(vttCueTexts(assBody(["{\\p1}m 0 0 l 10 10{\\p0}Hello World"]))),
+  JSON.stringify(["Hello World"])
+);
+
+check(
+  "dialogue before unclosed drawing is preserved",
+  JSON.stringify(vttCueTexts(assBody(["Sign {\\p1}m 0 0 l 10 10"]))),
+  JSON.stringify(["Sign"])
+);
+
+// --- App converter: non-drawing overrides keep historical behavior. ---
+check(
+  "positioned dialogue is preserved",
+  JSON.stringify(vttCueTexts(assBody(["{\\an8\\pos(1011.12,955.26)\\fsp0}The Culling Game"]))),
+  JSON.stringify(["The Culling Game"])
+);
+
+check(
+  "pbo/fsp0 tags are not drawings",
+  JSON.stringify(vttCueTexts(assBody(["{\\pbo-50}Lifted", "{\\an8\\fsp0}Wide"]))),
+  JSON.stringify(["Lifted", "Wide"])
+);
+
+check(
+  "plain dialogue untouched",
+  JSON.stringify(vttCueTexts(assBody(["Just text", "1, 2, 3, 4, 5, 6"]))),
+  JSON.stringify(["Just text", "1, 2, 3, 4, 5, 6"])
+);
+
+// --- Service VTT window: drawings absent from readable text, kept for ass.js. ---
+const track = { codecId: "S_TEXT/ASS" };
+const toPayload = (line) => Buffer.from(line, "utf8");
+const drawingLine =
+  "Dialogue: 0,0:00:15.00,0:00:17.00,Default,,0,0,0,,{\\p1}m 64.89 68.77 l 64.17 67.11{\\p0}";
+const normalLine = "Dialogue: 0,0:00:18.00,0:00:20.00,Default,,0,0,0,,Normal line";
+const window = service.buildTextSubtitleWindowPayload(
+  track,
+  [
+    { payload: toPayload(drawingLine), timestampMs: 15000, durationMs: 2000 },
+    { payload: toPayload(normalLine), timestampMs: 18000, durationMs: 2000 }
+  ],
+  0,
+  60000,
+  { includeAssBody: true }
+);
+
+check("VTT body has no drawing coordinates", window.body.includes("64.89"), false);
+check("VTT body keeps readable cue", window.body.includes("Normal line"), true);
+check(
+  "ASS body keeps drawing payload for ass.js",
+  window.assBody.includes("{\\p1}m 64.89 68.77 l 64.17 67.11{\\p0}"),
+  true
+);
+
+if (failures > 0) {
+  console.error(`${failures} failing case(s)`);
+  process.exit(1);
+}
+console.log("All ASS drawing fallback cases pass.");

--- a/scripts/test-ass-plaintext-fallback.mjs
+++ b/scripts/test-ass-plaintext-fallback.mjs
@@ -133,6 +133,7 @@ const taggedLine =
   "Dialogue: 0,0:00:13.00,0:00:14.00,Default,,0,0,0,,{\\an8\\pos(1011.12,955.26)}Placed";
 const normalLine = "Dialogue: 0,0:00:18.00,0:00:20.00,Default,,0,0,0,,Normal line";
 const bracesLine = "Dialogue: 0,0:00:21.00,0:00:23.00,Default,,0,0,0,,a}b";
+const tailLine = "Dialogue: 0,0:00:22.00,0:00:24.00,Default,,0,0,0,,Tail {\\fad(200,200";
 const window = service.buildTextSubtitleWindowPayload(
   track,
   [
@@ -140,7 +141,8 @@ const window = service.buildTextSubtitleWindowPayload(
     { payload: toPayload(fragmentLine), timestampMs: 12000, durationMs: 2000 },
     { payload: toPayload(taggedLine), timestampMs: 13000, durationMs: 1000 },
     { payload: toPayload(normalLine), timestampMs: 18000, durationMs: 2000 },
-    { payload: toPayload(bracesLine), timestampMs: 21000, durationMs: 2000 }
+    { payload: toPayload(bracesLine), timestampMs: 21000, durationMs: 2000 },
+    { payload: toPayload(tailLine), timestampMs: 22000, durationMs: 2000 }
   ],
   0,
   60000,
@@ -153,6 +155,8 @@ check("VTT body keeps readable cue", window.body.includes("Normal line"), true);
 check("VTT body keeps placed cue text", window.body.includes("Placed"), true);
 check("VTT body has no override braces", window.body.includes("{\\an8"), false);
 check("VTT body keeps brace prose", window.body.includes("a}b"), true);
+check("VTT body cuts truncated tail, keeps head", window.body.includes("Tail"), true);
+check("VTT body has no tail residue", window.body.includes("fad(200,200"), false);
 check(
   "ASS body keeps drawing payload for ass.js",
   window.assBody.includes("{\\p1}m 64.89 68.77 l 64.17 67.11{\\p0}"),

--- a/scripts/test-ass-plaintext-fallback.mjs
+++ b/scripts/test-ass-plaintext-fallback.mjs
@@ -1,6 +1,6 @@
 // Focused regression tests: plain-text subtitle pipelines (VTT/HTML/native
-// fallback) must never project ASS internals as cue text, and must never
-// drop legitimate dialogue to achieve it.
+// fallback) must never project ASS internals as cue text, and must rescue
+// legitimate dialogue following orphan tag prefixes.
 // Run: node ./scripts/test-ass-plaintext-fallback.mjs
 //
 // Covered units:
@@ -8,10 +8,6 @@
 // - services/webos/src/bitmapSubtitles.js (embedded VTT window body and ASS
 //   body event filtering; the ASS body keeps well-formed payloads untouched
 //   for ass.js).
-//
-// Deliberate non-goals (documented, need Format-aware work elsewhere):
-// - short-header event recovery (no guessing where Text starts);
-// - digit-suffixed commands without parens/ampersands (e.g. bare `\fsp0.0`).
 
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -76,13 +72,21 @@ check(
   JSON.stringify(["Sign"])
 );
 
-// --- Override fragments are suppressed, never projected. ---
+// --- Orphan tag prefixes are stripped, rescuing the readable dialogue. ---
 check(
-  "mid-tag fragment yields no cue",
+  "mid-tag fragment rescues dialogue (Menacing)",
   JSON.stringify(
     vttCueTexts(assBody(["320,820,640)\\frz358.4\\org(1889.15,82.92)\\c&H1B1516&}Menacing"]))
   ),
-  JSON.stringify([])
+  JSON.stringify(["Menacing"])
+);
+
+check(
+  "mid-tag fragment rescues dialogue (Culling Game)",
+  JSON.stringify(
+    vttCueTexts(assBody(["11.12,955.26,-783.88)\\fsp0.01}The Culling Game's Objective"]))
+  ),
+  JSON.stringify(["The Culling Game's Objective"])
 );
 
 // --- Legitimate text is never dropped. ---
@@ -129,6 +133,8 @@ const drawingLine =
   "Dialogue: 0,0:00:15.00,0:00:17.00,Default,,0,0,0,,{\\p1}m 64.89 68.77 l 64.17 67.11{\\p0}";
 const fragmentLine =
   "Dialogue: 0,0:00:12.00,0:00:14.00,Default,,0,0,0,,320,820,640)\\frz358.4\\org(1889.15,82.92)\\c&H1B1516&}Menacing";
+const cullingGameLine =
+  "Dialogue: 0,0:00:10.00,0:00:12.00,Default,,0,0,0,,11.12,955.26,-783.88)\\fsp0.01}The Culling Game's Objective";
 const taggedLine =
   "Dialogue: 0,0:00:13.00,0:00:14.00,Default,,0,0,0,,{\\an8\\pos(1011.12,955.26)}Placed";
 const normalLine = "Dialogue: 0,0:00:18.00,0:00:20.00,Default,,0,0,0,,Normal line";
@@ -139,6 +145,7 @@ const window = service.buildTextSubtitleWindowPayload(
   [
     { payload: toPayload(drawingLine), timestampMs: 15000, durationMs: 2000 },
     { payload: toPayload(fragmentLine), timestampMs: 12000, durationMs: 2000 },
+    { payload: toPayload(cullingGameLine), timestampMs: 10000, durationMs: 2000 },
     { payload: toPayload(taggedLine), timestampMs: 13000, durationMs: 1000 },
     { payload: toPayload(normalLine), timestampMs: 18000, durationMs: 2000 },
     { payload: toPayload(bracesLine), timestampMs: 21000, durationMs: 2000 },
@@ -151,6 +158,12 @@ const window = service.buildTextSubtitleWindowPayload(
 
 check("VTT body has no drawing coordinates", window.body.includes("64.89"), false);
 check("VTT body has no tag fragment", window.body.includes("frz358"), false);
+check("VTT body rescues Menacing dialogue", window.body.includes("Menacing"), true);
+check(
+  "VTT body rescues Culling Game dialogue",
+  window.body.includes("The Culling Game's Objective"),
+  true
+);
 check("VTT body keeps readable cue", window.body.includes("Normal line"), true);
 check("VTT body keeps placed cue text", window.body.includes("Placed"), true);
 check("VTT body has no override braces", window.body.includes("{\\an8"), false);
@@ -162,7 +175,12 @@ check(
   window.assBody.includes("{\\p1}m 64.89 68.77 l 64.17 67.11{\\p0}"),
   true
 );
-check("ASS body drops fragment event", window.assBody.includes("frz358"), false);
+check("ASS body rescues Menacing without fragment", window.assBody.includes(",,Menacing"), true);
+check(
+  "ASS body rescues Culling Game without fragment",
+  window.assBody.includes(",,The Culling Game's Objective"),
+  true
+);
 check(
   "ASS body keeps tagged event intact",
   window.assBody.includes("{\\an8\\pos(1011.12,955.26)}Placed"),

--- a/scripts/test-ass-plaintext-fallback.mjs
+++ b/scripts/test-ass-plaintext-fallback.mjs
@@ -2,12 +2,6 @@
 // fallback) must never project ASS internals as cue text, and must rescue
 // legitimate dialogue following orphan tag prefixes.
 // Run: node ./scripts/test-ass-plaintext-fallback.mjs
-//
-// Covered units:
-// - js/core/player/assSubtitle.js (external-file VTT fallback)
-// - services/webos/src/bitmapSubtitles.js (embedded VTT window body and ASS
-//   body event filtering; the ASS body keeps well-formed payloads untouched
-//   for ass.js).
 
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -89,6 +83,19 @@ check(
   JSON.stringify(["The Culling Game's Objective"])
 );
 
+// --- Pure unbraced tag fragments with no dialogue are dropped. ---
+check(
+  "unbraced digit-suffixed tag fragment yields no cue",
+  JSON.stringify(vttCueTexts(assBody(["11.12,955.26,-783.88)\\fsp0.01"]))),
+  JSON.stringify([])
+);
+
+check(
+  "unbraced command with parens yields no cue",
+  JSON.stringify(vttCueTexts(assBody(["\\pos(10,20)"]))),
+  JSON.stringify([])
+);
+
 // --- Legitimate text is never dropped. ---
 check(
   "positioned dialogue is preserved",
@@ -131,10 +138,14 @@ const track = { codecId: "S_TEXT/ASS" };
 const toPayload = (line) => Buffer.from(line, "utf8");
 const drawingLine =
   "Dialogue: 0,0:00:15.00,0:00:17.00,Default,,0,0,0,,{\\p1}m 64.89 68.77 l 64.17 67.11{\\p0}";
+const unclosedDrawingLine =
+  "Dialogue: 0,0:00:16.00,0:00:17.00,Default,,0,0,0,,{\\p1}m 10 20 l 30 40";
 const fragmentLine =
   "Dialogue: 0,0:00:12.00,0:00:14.00,Default,,0,0,0,,320,820,640)\\frz358.4\\org(1889.15,82.92)\\c&H1B1516&}Menacing";
 const cullingGameLine =
   "Dialogue: 0,0:00:10.00,0:00:12.00,Default,,0,0,0,,11.12,955.26,-783.88)\\fsp0.01}The Culling Game's Objective";
+const pureFragmentLine =
+  "Dialogue: 0,0:00:11.00,0:00:12.00,Default,,0,0,0,,11.12,955.26,-783.88)\\fsp0.01";
 const taggedLine =
   "Dialogue: 0,0:00:13.00,0:00:14.00,Default,,0,0,0,,{\\an8\\pos(1011.12,955.26)}Placed";
 const normalLine = "Dialogue: 0,0:00:18.00,0:00:20.00,Default,,0,0,0,,Normal line";
@@ -144,8 +155,10 @@ const window = service.buildTextSubtitleWindowPayload(
   track,
   [
     { payload: toPayload(drawingLine), timestampMs: 15000, durationMs: 2000 },
+    { payload: toPayload(unclosedDrawingLine), timestampMs: 16000, durationMs: 1000 },
     { payload: toPayload(fragmentLine), timestampMs: 12000, durationMs: 2000 },
     { payload: toPayload(cullingGameLine), timestampMs: 10000, durationMs: 2000 },
+    { payload: toPayload(pureFragmentLine), timestampMs: 11000, durationMs: 1000 },
     { payload: toPayload(taggedLine), timestampMs: 13000, durationMs: 1000 },
     { payload: toPayload(normalLine), timestampMs: 18000, durationMs: 2000 },
     { payload: toPayload(bracesLine), timestampMs: 21000, durationMs: 2000 },
@@ -157,7 +170,9 @@ const window = service.buildTextSubtitleWindowPayload(
 );
 
 check("VTT body has no drawing coordinates", window.body.includes("64.89"), false);
+check("VTT body has no unclosed drawing coordinates", window.body.includes("10 20"), false);
 check("VTT body has no tag fragment", window.body.includes("frz358"), false);
+check("VTT body has no pure unbraced fragment", window.body.includes("fsp0.01"), false);
 check("VTT body rescues Menacing dialogue", window.body.includes("Menacing"), true);
 check(
   "VTT body rescues Culling Game dialogue",

--- a/scripts/test-ass-plaintext-fallback.mjs
+++ b/scripts/test-ass-plaintext-fallback.mjs
@@ -1,13 +1,17 @@
-// Focused regression tests: ASS vector drawings must never surface as
-// readable cue text in plain-text pipelines (VTT/HTML/native fallback).
-// Run: node ./scripts/test-ass-drawing-fallback.mjs
-// A drawing section carries no dialogue by ASS semantics (ass.js renders it
-// as a vector shape with empty text, and text after an unclosed \p block is
-// drawing data up to the event end), so suppressing it cannot truncate
-// legitimate dialogue. Covered units:
+// Focused regression tests: plain-text subtitle pipelines (VTT/HTML/native
+// fallback) must never project ASS internals as cue text, and must never
+// drop legitimate dialogue to achieve it.
+// Run: node ./scripts/test-ass-plaintext-fallback.mjs
+//
+// Covered units:
 // - js/core/player/assSubtitle.js (external-file VTT fallback)
-// - services/webos/src/bitmapSubtitles.js (embedded VTT window body; the ASS
-//   body must keep the original payload so ass.js still draws the shapes).
+// - services/webos/src/bitmapSubtitles.js (embedded VTT window body and ASS
+//   body event filtering; the ASS body keeps well-formed payloads untouched
+//   for ass.js).
+//
+// Deliberate non-goals (documented, need Format-aware work elsewhere):
+// - short-header event recovery (no guessing where Text starts);
+// - digit-suffixed commands without parens/ampersands (e.g. bare `\fsp0.0`).
 
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -52,14 +56,14 @@ function assBody(textLines) {
   ].join("\n");
 }
 
-// --- App converter: drawing-only cues produce no cue. ---
+// --- Drawings carry no dialogue: drawing-only cues produce no cue. ---
 check(
   "drawing-only event yields no cue",
   JSON.stringify(vttCueTexts(assBody(["{\\p1}m 64.89 68.77 l 64.17 67.11 l 63.09 66.4{\\p0}"]))),
   JSON.stringify([])
 );
 
-// --- App converter: dialogue adjacent to drawings is preserved. ---
+// --- Dialogue adjacent to drawings is preserved. ---
 check(
   "dialogue after closed drawing is preserved",
   JSON.stringify(vttCueTexts(assBody(["{\\p1}m 0 0 l 10 10{\\p0}Hello World"]))),
@@ -72,7 +76,16 @@ check(
   JSON.stringify(["Sign"])
 );
 
-// --- App converter: non-drawing overrides keep historical behavior. ---
+// --- Override fragments are suppressed, never projected. ---
+check(
+  "mid-tag fragment yields no cue",
+  JSON.stringify(
+    vttCueTexts(assBody(["320,820,640)\\frz358.4\\org(1889.15,82.92)\\c&H1B1516&}Menacing"]))
+  ),
+  JSON.stringify([])
+);
+
+// --- Legitimate text is never dropped. ---
 check(
   "positioned dialogue is preserved",
   JSON.stringify(vttCueTexts(assBody(["{\\an8\\pos(1011.12,955.26)\\fsp0}The Culling Game"]))),
@@ -91,17 +104,43 @@ check(
   JSON.stringify(["Just text", "1, 2, 3, 4, 5, 6"])
 );
 
-// --- Service VTT window: drawings absent from readable text, kept for ass.js. ---
+check(
+  "unbalanced braces without backslash are preserved",
+  JSON.stringify(vttCueTexts(assBody(["a}b"]))),
+  JSON.stringify(["a}b"])
+);
+
+check(
+  "backslash path without commands is preserved",
+  JSON.stringify(vttCueTexts(assBody(["C:\\path (x86)\\app"]))),
+  JSON.stringify(["C:\\path (x86)\\app"])
+);
+
+check(
+  "truncated tail block is cut, head preserved",
+  JSON.stringify(vttCueTexts(assBody(["Tail {\\fad(200,200"]))),
+  JSON.stringify(["Tail"])
+);
+
+// --- Service VTT window: same guarantees end to end. ---
 const track = { codecId: "S_TEXT/ASS" };
 const toPayload = (line) => Buffer.from(line, "utf8");
 const drawingLine =
   "Dialogue: 0,0:00:15.00,0:00:17.00,Default,,0,0,0,,{\\p1}m 64.89 68.77 l 64.17 67.11{\\p0}";
+const fragmentLine =
+  "Dialogue: 0,0:00:12.00,0:00:14.00,Default,,0,0,0,,320,820,640)\\frz358.4\\org(1889.15,82.92)\\c&H1B1516&}Menacing";
+const taggedLine =
+  "Dialogue: 0,0:00:13.00,0:00:14.00,Default,,0,0,0,,{\\an8\\pos(1011.12,955.26)}Placed";
 const normalLine = "Dialogue: 0,0:00:18.00,0:00:20.00,Default,,0,0,0,,Normal line";
+const bracesLine = "Dialogue: 0,0:00:21.00,0:00:23.00,Default,,0,0,0,,a}b";
 const window = service.buildTextSubtitleWindowPayload(
   track,
   [
     { payload: toPayload(drawingLine), timestampMs: 15000, durationMs: 2000 },
-    { payload: toPayload(normalLine), timestampMs: 18000, durationMs: 2000 }
+    { payload: toPayload(fragmentLine), timestampMs: 12000, durationMs: 2000 },
+    { payload: toPayload(taggedLine), timestampMs: 13000, durationMs: 1000 },
+    { payload: toPayload(normalLine), timestampMs: 18000, durationMs: 2000 },
+    { payload: toPayload(bracesLine), timestampMs: 21000, durationMs: 2000 }
   ],
   0,
   60000,
@@ -109,15 +148,26 @@ const window = service.buildTextSubtitleWindowPayload(
 );
 
 check("VTT body has no drawing coordinates", window.body.includes("64.89"), false);
+check("VTT body has no tag fragment", window.body.includes("frz358"), false);
 check("VTT body keeps readable cue", window.body.includes("Normal line"), true);
+check("VTT body keeps placed cue text", window.body.includes("Placed"), true);
+check("VTT body has no override braces", window.body.includes("{\\an8"), false);
+check("VTT body keeps brace prose", window.body.includes("a}b"), true);
 check(
   "ASS body keeps drawing payload for ass.js",
   window.assBody.includes("{\\p1}m 64.89 68.77 l 64.17 67.11{\\p0}"),
   true
 );
+check("ASS body drops fragment event", window.assBody.includes("frz358"), false);
+check(
+  "ASS body keeps tagged event intact",
+  window.assBody.includes("{\\an8\\pos(1011.12,955.26)}Placed"),
+  true
+);
+check("ASS body keeps brace prose event", window.assBody.includes(",,a}b"), true);
 
 if (failures > 0) {
   console.error(`${failures} failing case(s)`);
   process.exit(1);
 }
-console.log("All ASS drawing fallback cases pass.");
+console.log("All ASS plain-text fallback cases pass.");

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1639,7 +1639,8 @@ function hasUnbalancedAssMarkup(value) {
   return text.split("{").length !== text.split("}").length;
 }
 
-var ASS_TAG_SOUP_RE = /\\[A-Za-z]+[(\&]/;
+var ASS_TAG_SOUP_RE =
+  /\\[A-Za-z]+[(\&]|\\(?:pos|move|org|clip|iclip|fad|fade|t)\s*\(|\\(?:[1-4]?c|alpha|[1-4]?a)&|\\(?:an[1-9]|fsp[-+]?\d|fs\d|fr[xyz]?[-+]?\d|x?bord\d|x?shad\d|blur\d|be\d|q[0-3]|pbo[-+]?\d)(?=[^A-Za-z]|$)/i;
 
 // See js/core/player/assSubtitle.js: true only for override-tag residue
 // (backslash command with unbalanced braces, or with `(`/`&` and no block).
@@ -1666,6 +1667,7 @@ function sanitizePlainTextAssCue(text) {
       // the tag residue up to `}` so the readable dialogue is rescued.
       .replace(/^[^{}\n]*\\[^{}\n]*\}/, "")
       .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
+      .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "")
       .replace(/\{[^}]*\}/g, "")
       // A truncated final override block (no closing brace) is tag source,
       // not dialogue — same parity as the app converter.

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1621,13 +1621,25 @@ function formatVttTimestamp(timestampMs) {
   return formatTimestamp(timestampMs).replace(/:(\d{3})$/, ".$1");
 }
 
+// Vector drawings (\\p1...\\p0) carry no readable dialogue. Strip closed
+// drawing sections (and unclosed ones running to the event end, per ASS
+// semantics) from the readable-text body only; the ASS body keeps the
+// original payload so ass.js still renders the shapes.
+function stripAssDrawingSections(text) {
+  return String(text || "")
+    .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
+    .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "");
+}
+
 function buildTextSubtitleWindowPayload(track, frames, startMs, endMs, options) {
   var cueBlocks = [];
   var outputBytes = Buffer.byteLength("WEBVTT\n\n", "utf8");
   var hasOverrides = false;
   var hasAdvancedOverrides = false;
   frames.forEach(function (frame, index) {
-    var text = normalizeTextSubtitlePayload(track, frame.payload);
+    var rawText = normalizeTextSubtitlePayload(track, frame.payload);
+    if (!rawText) return;
+    var text = stripAssDrawingSections(rawText);
     if (!text) return;
     var cueStartMs = Number(frame.timestampMs);
     var cueEndMs = getTextCueEndMs(frame, frames[index + 1]);
@@ -1648,8 +1660,8 @@ function buildTextSubtitleWindowPayload(track, frames, startMs, endMs, options) 
     }
     outputBytes += blockBytes;
     cueBlocks.push(block);
-    hasOverrides = hasOverrides || hasAssOverrideTags(text);
-    hasAdvancedOverrides = hasAdvancedOverrides || hasAdvancedAssOverrideTags(text);
+    hasOverrides = hasOverrides || hasAssOverrideTags(rawText);
+    hasAdvancedOverrides = hasAdvancedOverrides || hasAdvancedAssOverrideTags(rawText);
   });
   var body = "WEBVTT\n\n" + (cueBlocks.length ? cueBlocks.join("\n\n") + "\n\n" : "");
   var includeAssBody =

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1658,10 +1658,15 @@ function looksLikeAssTagSoup(text) {
 // override blocks so only readable text ships. The ASS body keeps the
 // original payload for ass.js.
 function sanitizePlainTextAssCue(text) {
-  return String(text || "")
-    .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
-    .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "")
-    .replace(/\{[^}]*\}/g, "");
+  return (
+    String(text || "")
+      .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
+      .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "")
+      .replace(/\{[^}]*\}/g, "")
+      // A truncated final override block (no closing brace) is tag source,
+      // not dialogue — same parity as the app converter.
+      .replace(/\{[^\n}]*$/gm, "")
+  );
 }
 
 function buildTextSubtitleWindowPayload(track, frames, startMs, endMs, options) {

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1269,6 +1269,13 @@ function getAssDialogueText(track, frame) {
 function buildAssDialogueLine(track, frame, nextFrame) {
   var text = getAssDialogueText(track, frame);
   if (!text) return "";
+  // A Text field with dangling markup (backslash plus unbalanced braces) is
+  // a corrupt slice, not dialogue: ass.js would project it literally, so the
+  // event is dropped. Balanced tagged text is preserved untouched.
+  var markupCheck = stripAssTextEscapes(text);
+  if (markupCheck.indexOf("\\") >= 0 && hasUnbalancedAssMarkup(markupCheck)) {
+    return "";
+  }
   var startMs = Number(frame && frame.timestampMs);
   var endMs = getTextCueEndMs(frame, nextFrame);
   if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return "";
@@ -1621,14 +1628,40 @@ function formatVttTimestamp(timestampMs) {
   return formatTimestamp(timestampMs).replace(/:(\d{3})$/, ".$1");
 }
 
-// Vector drawings (\\p1...\\p0) carry no readable dialogue. Strip closed
-// drawing sections (and unclosed ones running to the event end, per ASS
-// semantics) from the readable-text body only; the ASS body keeps the
-// original payload so ass.js still renders the shapes.
-function stripAssDrawingSections(text) {
+function stripAssTextEscapes(value) {
+  return String(value || "").replace(/\\\\|\\[NnHh]/g, "");
+}
+
+function hasUnbalancedAssMarkup(value) {
+  var text = String(value || "");
+  return text.split("{").length !== text.split("}").length;
+}
+
+var ASS_TAG_SOUP_RE = /\\[A-Za-z]+[(\&]/;
+
+// See js/core/player/assSubtitle.js: true only for override-tag residue
+// (backslash command with unbalanced braces, or with `(`/`&` and no block).
+// Legitimate dialogue, including backslash paths, never matches.
+function looksLikeAssTagSoup(text) {
+  var value = stripAssTextEscapes(text);
+  if (value.indexOf("\\") < 0) {
+    return false;
+  }
+  if (hasUnbalancedAssMarkup(value)) {
+    return true;
+  }
+  return ASS_TAG_SOUP_RE.test(value);
+}
+
+// Plain-text pipelines (VTT/HTML/native) cannot render ASS vector drawings
+// or truncated override blocks: drop drawing sections and strip balanced
+// override blocks so only readable text ships. The ASS body keeps the
+// original payload for ass.js.
+function sanitizePlainTextAssCue(text) {
   return String(text || "")
     .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
-    .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "");
+    .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "")
+    .replace(/\{[^}]*\}/g, "");
 }
 
 function buildTextSubtitleWindowPayload(track, frames, startMs, endMs, options) {
@@ -1639,8 +1672,8 @@ function buildTextSubtitleWindowPayload(track, frames, startMs, endMs, options) 
   frames.forEach(function (frame, index) {
     var rawText = normalizeTextSubtitlePayload(track, frame.payload);
     if (!rawText) return;
-    var text = stripAssDrawingSections(rawText);
-    if (!text) return;
+    var text = sanitizePlainTextAssCue(rawText);
+    if (!text || looksLikeAssTagSoup(text)) return;
     var cueStartMs = Number(frame.timestampMs);
     var cueEndMs = getTextCueEndMs(frame, frames[index + 1]);
     if (!Number.isFinite(cueStartMs) || cueEndMs <= startMs || cueStartMs >= endMs) return;

--- a/services/webos/src/bitmapSubtitles.js
+++ b/services/webos/src/bitmapSubtitles.js
@@ -1267,11 +1267,14 @@ function getAssDialogueText(track, frame) {
 }
 
 function buildAssDialogueLine(track, frame, nextFrame) {
-  var text = getAssDialogueText(track, frame);
-  if (!text) return "";
-  // A Text field with dangling markup (backslash plus unbalanced braces) is
-  // a corrupt slice, not dialogue: ass.js would project it literally, so the
-  // event is dropped. Balanced tagged text is preserved untouched.
+  var rawText = getAssDialogueText(track, frame);
+  if (!rawText) return "";
+  // Drop orphan tag prefix if present (e.g. `...)\frz...}`) so ass.js
+  // receives clean text instead of projecting it literally.
+  var text = rawText.replace(/^[^{}\n]*\\[^{}\n]*\}/, "");
+  // A Text field with remaining dangling markup (backslash plus unbalanced
+  // braces) is a corrupt slice, not dialogue: ass.js would project it
+  // literally, so the event is dropped. Balanced tagged text is preserved.
   var markupCheck = stripAssTextEscapes(text);
   if (markupCheck.indexOf("\\") >= 0 && hasUnbalancedAssMarkup(markupCheck)) {
     return "";
@@ -1279,15 +1282,15 @@ function buildAssDialogueLine(track, frame, nextFrame) {
   var startMs = Number(frame && frame.timestampMs);
   var endMs = getTextCueEndMs(frame, nextFrame);
   if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return "";
+  var assText = text.replace(/\r?\n/g, "\\N");
   var raw = decodeTextSubtitlePayload(frame && frame.payload);
   var event = raw.replace(/^\s*Dialogue\s*:\s*/i, "");
   var fields = event.split(",");
   if (fields.length >= 10 && isAssTimestamp(fields[1]) && isAssTimestamp(fields[2])) {
     fields[1] = formatAssTimestamp(startMs);
     fields[2] = formatAssTimestamp(endMs);
-    return "Dialogue: " + fields.slice(0, 9).concat(fields.slice(9).join(",")).join(",");
+    return "Dialogue: " + fields.slice(0, 9).concat(assText).join(",");
   }
-  // Preserve leading ASS fields only for the two shapes that carry them.
   // Metadata alone is not enough: webOS can expose ordinary cue text as a
   // comma-separated row, and treating its first fields as Style/Name/Margins
   // duplicates that prefix in the generated Dialogue line.
@@ -1302,7 +1305,6 @@ function buildAssDialogueLine(track, frame, nextFrame) {
     /^-?\d+$/.test(String(fields[6] || "").trim()) &&
     String(fields[7] || "").trim() === "";
   var hasStructuredFields = hasShortTiming || hasPositionalShape;
-  var assText = text.replace(/\r?\n/g, "\\N");
   // Positional form carries the ASS Layer in fields[0]; short SSA has none,
   // so default it to 0. Preserve a non-zero layer to keep stacking order.
   var layer = hasPositionalShape ? String(fields[0] || "").trim() || "0" : "0";
@@ -1660,8 +1662,10 @@ function looksLikeAssTagSoup(text) {
 function sanitizePlainTextAssCue(text) {
   return (
     String(text || "")
+      // An orphan override block fragment sliced mid-tag before `{`: drop
+      // the tag residue up to `}` so the readable dialogue is rescued.
+      .replace(/^[^{}\n]*\\[^{}\n]*\}/, "")
       .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*?\{[^}]*\\p0[^}]*\}/gi, "")
-      .replace(/\{[^}]*\\p[1-9][^}]*\}[\s\S]*$/gi, "")
       .replace(/\{[^}]*\}/g, "")
       // A truncated final override block (no closing brace) is tag source,
       // not dialogue — same parity as the app converter.


### PR DESCRIPTION
## Summary

- Suppress ASS override-tag residue (mid-tag fragments, vector-drawing path data) in plain-text subtitle pipelines (VTT/HTML/native fallback), where it is currently projected as visible garbage: coordinate walls and tag source on screen.
- Drop corrupt-slice events from the reconstructed ASS body so ass.js never renders tag source literally, while well-formed payloads (including drawings, for vector rendering) pass through untouched.
- Add `scripts/test-ass-plaintext-fallback.mjs` with 20 focused regression cases.

## PR type

- [x] Critical bug fix

## Affected area

- [x] Shared web app
- [x] LG webOS
- [x] Playback
- [x] Subtitles

## Why

Follow-up to #876 without its contested parts: this PR contains no event-splitting changes and no Text-position guessing, so it cannot truncate legitimate dialogue. It only suppresses output that is provably markup residue.

Reproduced cases (internal ASS, webOS):

1. Mid-tag fragments such as `320,820,640)\frz358.4\org(1889.15,82.92)\c&H1B1516&}Menacing` reach both the VTT body and the ASS body and render literally in every renderer (no balanced `{...}` for any sanitizer or ass.js `parseText` to act on).
2. Vector drawings (`{\p1}m 64.89 68.77 l ...{\p0}`) lose their wrappers in plain-text conversion but keep path data, rendering full-screen coordinate walls.

## Issue or approval

Fixes ASS internals projected as subtitle text in fallback paths and in reconstructed ASS bodies.

## Reproduction steps

1. Play content with internal ASS containing override-heavy typesetting or `\p` drawings on webOS.
2. Observe tag fragments / coordinate walls in fallback rendering (or literal fragments via ass.js).

Node repros: `normalizeTextSubtitlePayload` on a short-header event returns the mid-tag fragment; `convertAssDialogueToVttCues` on a drawing-only event emits `m 64.89 68.77 l ...` as cue text. Both fixed here; see tests.

## Old behavior

- Tag fragments and drawing path data shipped as cue text in VTT/HTML/native fallbacks and in reconstructed ASS bodies.

## New behavior

- `sanitizeAssDialogueText` / `sanitizePlainTextAssCue`: drop closed `\p1...\p0` drawing sections (and unclosed ones running to event end, per ASS spec — ass.js renders those spans as shape-only too, so parity holds) and strip balanced override blocks.
- New `looksLikeAssTagSoup` predicate drops cues whose final text is override residue (backslash command with unbalanced braces, or with `(`/`&` and no block). Ordinary dialogue — including backslash paths (`C:\path (x86)`), `a}b`-style braces, plain CSV, `\pbo`, `\fsp0` — is preserved (asserted by tests).
- `buildAssDialogueLine` drops events whose Text field is a corrupt slice (backslash plus unbalanced braces); balanced tagged text passes through untouched for ass.js.
- No event-splitting logic touched: `textAfterCommaCount` call sites keep their exact historical splits; short-header recovery is explicitly out of scope.

## Platform impact

- Samsung Tizen: converter behavior identical except suppressed residue.
- LG webOS: VTT window bodies no longer carry drawings/fragments; ASS bodies drop corrupt-slice events only.
- Browser development mode: same converter behavior for external ASS fallback.
- Installer / packaging: none.
- Wrapper repositories: none.

## UI / behavior / playback impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

`js/core/player/assSubtitle.js` (soup predicate + converter check), `services/webos/src/bitmapSubtitles.js` (VTT helper + site check + corrupt-slice event drop), `scripts/test-ass-plaintext-fallback.mjs` (new, standalone, not wired into CI). No splitting, detection, selection, renderer-lifecycle, or veto changes. Explicit non-goals: short-header Text recovery and bare digit-suffixed commands without parens/ampersands.

## Testing

### Commands tested

```sh
node ./scripts/test-ass-plaintext-fallback.mjs
node --check js/core/player/assSubtitle.js
node --check services/webos/src/bitmapSubtitles.js
git diff --check
npx prettier --check js/core/player/assSubtitle.js services/webos/src/bitmapSubtitles.js scripts/test-ass-plaintext-fallback.mjs
```

27/27 cases pass: drawing-only cues dropped; adjacent dialogue preserved (closed and unclosed drawings); fragments dropped in converter, VTT body, and ASS body; positioned/plain/CSV/brace-prose/path text preserved; truncated tails cut with head kept (app and service parity); drawing payloads intact in ASS body for ass.js.

## Manual test flow

Not tested on TV hardware in this session; verification is via the service/app-level repros above. Needs on-device confirmation with typeset episodes.

## Screenshots / Video

Reporter photos show the before state (override fragments, coordinate walls).

## Logs

Not applicable.

## Regression risk

Low. Suppression triggers only on backslash-command residue; every legitimate-text class is asserted preserved by tests. Well-formed events follow byte-identical paths (no splitting changes).

## Breaking changes

None.


