### PR TITLE
fix(tizen): single metadata ASS detection in AVPlay subtitle overlay

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -16824,17 +16824,7 @@ export const PlayerScreen = {
     if (!text) {
       return false;
     }
-    // AVPlay may expose the complete SSA event or its positional CSV fields.
-    // Strip only the control prefix for structural validation; plain cue text
-    // such as "Dialogue: hello" must remain renderable.
     const payload = text.replace(/^\s*(?:Dialogue|Comment)\s*:\s*/i, "");
-    const hasAssTiming =
-      /^(?:(?:\d+|Marked\s*=\s*\d+)\s*,\s*)?\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}\s*,\s*\d+:\d{1,2}:\d{1,2}[.,]\d{1,3}\s*,/i.test(
-        payload
-      );
-    if (hasAssTiming) {
-      return true;
-    }
     if (/[.!?\u00C0-\u024F]/.test(text)) {
       return false;
     }
@@ -16844,6 +16834,26 @@ export const PlayerScreen = {
       /^\s*\d+\s*,\s*\d+\s*,\s*(?:Onscreen\d*|Screen)\s*,/i.test(payload) &&
       payload.split(",").length >= 6
     );
+  },
+
+  isSelectedAvPlaySubtitleAssTrack() {
+    const tracks = PlayerController.getAvPlaySubtitleTracks?.() || [];
+    const selected = PlayerController.getSelectedAvPlaySubtitleTrackIndex?.() ?? -1;
+    const track = tracks.find((entry) => Number(entry?.avplayTrackIndex) === Number(selected));
+    if (!track) {
+      return false;
+    }
+    // Firmware entries sometimes omit the codec or carry it as format; the
+    // probed embedded metadata fills those gaps (codecId/codec_name).
+    const embedded = this.getEmbeddedSubtitleTrackByNativeIndex(Number(track.avplayTrackIndex));
+    const codecs = [
+      track?.codec,
+      track?.format,
+      embedded?.codec,
+      embedded?.codecId,
+      embedded?.codec_name
+    ];
+    return codecs.some((value) => isAssSubtitleCodec(value));
   },
 
   renderAvPlaySubtitleChange(detail = {}) {
@@ -16880,10 +16890,25 @@ export const PlayerScreen = {
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/\r\n/g, "\n")
       .replace(/\r/g, "\n");
-    // Samsung AVPlay can expose SSA/ASS fields instead of dialogue text.
+    // Samsung AVPlay can expose positional SSA/ASS fields without dialogue text.
     // Never project that control payload into the video overlay.
-    const text = this.parseSubtitleCueText(rawText);
-    if (!text || this.isAvPlaySubtitleControlPayload(rawText)) {
+    if (this.isAvPlaySubtitleControlPayload(rawText)) {
+      this.renderHtmlSubtitleOverlayCue([]);
+      return;
+    }
+    // The selected track is already known to be ASS (or not) via codec
+    // metadata: strip the event header structurally, nothing else to check.
+    let dialogueText = rawText;
+    if (this.isSelectedAvPlaySubtitleAssTrack() && /^\s*(?:Dialogue|Comment)\s*:/i.test(rawText)) {
+      const fields = rawText.replace(/^\s*(?:Dialogue|Comment)\s*:/i, "").split(",");
+      if (fields.length >= 10) {
+        dialogueText = fields.slice(9).join(",");
+      } else if (fields.length >= 9) {
+        dialogueText = fields.slice(8).join(",");
+      }
+    }
+    const text = this.parseSubtitleCueText(dialogueText);
+    if (!text) {
       this.renderHtmlSubtitleOverlayCue([]);
       return;
     }


### PR DESCRIPTION
## Summary

- `renderAvPlaySubtitleChange` decides ASS-ness once from the selected AVPlay track's codec metadata (`isSelectedAvPlaySubtitleAssTrack` → `isAssSubtitleCodec` over codec/format/codecId/codec_name). No per-cue content sniffing.
- Removed the `hasAssTiming` false positive that classified every timestamped Dialogue row as a control payload and cleared the overlay.
- For ASS tracks, the event header is stripped structurally (Text column after 9 header columns, 8 for short rows); anything else passes through untouched, so plain `Dialogue: hello` prose keeps its prefix.
- Positional `Onscreen/Screen` rows without dialogue stay filtered (original #735 guard, unchanged).

## PR type

- [x] Critical bug fix

## Affected area

- [x] Samsung Tizen
- [x] Playback
- [x] Subtitles

## Why

In HTML overlay mode, Samsung AVPlay silences its hardware renderer and forwards subtitle events through `onsubtitlechange`. Because AVPlay does not parse ASS, it delivers raw Matroska packets (`Dialogue: 0,start,end,...`). Previously, `hasAssTiming` matched the timestamps and discarded every dialogue line as unrenderable control output, clearing the overlay to black. Meanwhile, with native rendering enabled, AVPlay printed the raw Dialogue line with timestamps and tags directly onto the video surface.

## Issue or approval

Fixes missing or raw ASS/SSA subtitles on Samsung Tizen when using the HTML subtitle overlay.

## Reproduction steps

1. On a Samsung Tizen TV, play media containing embedded or external SSA/ASS subtitles.
2. Select the SSA/ASS subtitle track.
3. Switch subtitle render mode to "HTML Overlay".
4. Before: no subtitles appear (every event dropped as control payload). After: clean dialogue renders.

## Old behavior

- Any `Dialogue:` or `Comment:` line with ASS timestamps was flagged as a control payload and dropped.

## New behavior

- ASS-ness comes from the selected track's codec metadata, evaluated once per callback.
- The event header is stripped structurally; `parseSubtitleCueText` strips `{...}` tags and decodes entities as before.
- `isAvPlaySubtitleControlPayload` only filters positional rows (`Onscreen1,Screen` with 6+ fields).
- `getSubtitleAssAlignment` still inspects the raw text for alignment positioning (e.g. `\an8`).

## Platform impact

- Samsung Tizen: SSA/ASS subtitles render cleanly via the HTML overlay without CSV headers, raw tags, or false-positive drops.
- LG webOS: No impact (path is gated behind `Environment.isTizen()` and `isUsingAvPlay()`; webOS filtering was already positional-only).
- Browser development mode: No impact.
- Installer / packaging: None.
- Wrapper repositories: None.

## UI / behavior / playback impact

- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `js/ui/screens/player/playerScreen.js`. No changes to webOS pipelines, track discovery, subtitle stylesheets, or new files.

## Testing

### Commands tested

```sh
node --check js/ui/screens/player/playerScreen.js
git diff --check
npx prettier --check js/ui/screens/player/playerScreen.js
```

### Behavioral checks (node, mirrored handler logic)

- Full ASS `Dialogue: 0,0:00:10.00,0:00:15.00,Default,,0,0,0,,{\pos(100,200)}Hola mundo` on ASS track → `{\pos(100,200)}Hola mundo` (tags stripped downstream as before).
- Short SSA on ASS track → text extracted.
- Same event on non-ASS track → untouched whole line.
- Plain text and `Dialogue: hello` prose → untouched.

## Manual test flow

Needs on-device confirmation on Samsung Tizen hardware with SSA/ASS media: subtitles must render cleanly via HTML overlay without CSV headers or raw tags.

## Screenshots / Video

Not applicable (fixes missing text on TV overlay).

## Logs

Not applicable.

## Regression risk

Low. Non-ASS path is byte-identical in behavior (positional guard first, then untouched passthrough). Previously every ASS event was dropped, so the ASS path has no working behavior to regress.

## Breaking changes

None.
