### PR TITLE
fix(player): restore next episode action

### DIFF
--- a/js/ui/screens/player/playerScreen.js
+++ b/js/ui/screens/player/playerScreen.js
@@ -9363,7 +9363,7 @@ export const PlayerScreen = {
       return false;
     }
     const shouldShow = this.getNextEpisodeCardThresholdReached(currentSeconds, durationSeconds);
-    if (this.nextEpisodeCardTriggered && !shouldShow) {
+    if (this.nextEpisodeCardTriggered && !this.nextEpisodeLaunching && !shouldShow) {
       this.resetNextEpisodeCardCycle({ render: false });
       return false;
     }
@@ -10056,7 +10056,7 @@ export const PlayerScreen = {
       (Boolean(settings.autoplayNextEpisode) ||
         Boolean(settings.streamAutoPlayPreferBingeGroupForNextEpisode));
     if (mode === "MANUAL" && !shouldAutoSelectInManualMode) {
-      return this.openNextEpisodeStreamPicker(nextEpisode, { forceReload: true });
+      return this.openNextEpisodeStreamPicker(nextEpisode, { forceReload: false });
     }
 
     const launchToken = Number(this.nextEpisodeLaunchToken || 0) + 1;


### PR DESCRIPTION
## Summary

Restore the Next Episode action and reuse prefetched streams.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [x] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [x] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Clicking Next Episode before the end-card threshold clears the launch state. Manual mode also ignores prefetched streams.

## Issue or approval

Fixes #890

## Reproduction steps

1. Play an episode with another aired episode after it.
2. Open the player controls.
3. Select Next Episode.

## Old behavior

Nothing visible happened and the current episode kept playing.

## New behavior

The next-episode action remains active and manual mode reuses prefetched streams.

## Platform impact

- Samsung Tizen: Shared player logic only.
- LG webOS: Fixes the reported player action.
- Browser development mode: Shared player logic only.
- Installer / packaging: None.
- Wrapper repositories: None.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

No UI, selection-policy, platform, dependency, or architecture changes.

## Testing

### Devices / platforms tested

LG C5, webOS 25, webOS Homebrew Channel.

### Commands tested

```sh
npm test
node ./tests/next-episode-regression.test.mjs
npm exec -- prettier --check js/ui/screens/player/playerScreen.js
git diff --check
```

## Manual test flow

Play a series episode, open the player controls, and select Next Episode.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Limited to Next Episode. Backward-seek reset and error refresh behavior remain unchanged.

## Breaking changes

None.

## Linked issues

Fixes #890