### PR TITLE
fix(player): allow larger webOS HLS buffer

### DIFF
--- a/js/core/player/playerController.js
+++ b/js/core/player/playerController.js
@@ -3746,7 +3746,7 @@ export const PlayerController = {
       initialLiveManifestSize: isWebOs && isLivePlayback ? WEBOS_LIVE_INITIAL_MANIFEST_SIZE : 1,
       backBufferLength: isWebOs ? 30 : 90,
       maxBufferLength: isWebOs ? 18 : 30,
-      maxMaxBufferLength: isWebOs ? 24 : 60,
+      maxMaxBufferLength: isWebOs ? 80 : 60,
       maxBufferHole: 0.5,
       startFragPrefetch: false,
       fragLoadingTimeOut: isWebOs ? 18000 : 20000,


### PR DESCRIPTION
## Summary

Raise the webOS HLS hard buffer cap from 24 to 80 seconds while keeping the 18-second target.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [x] LG webOS
- [ ] Browser development mode
- [x] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

The 24-second cap prevents hls.js from using its adaptive byte budget when bandwidth allows a larger buffer.

## Issue or approval

Fixes #893

## Reproduction steps

1. Play an HLS movie or episode on webOS.
2. Let playback continue on a connection faster than the stream bitrate.
3. Observe that buffered progress stops around 24 seconds ahead.

## Old behavior

webOS HLS playback could not buffer more than 24 seconds ahead.

## New behavior

The buffer can grow up to 80 seconds when allowed by hls.js's existing byte budget. The 18-second guaranteed target remains unchanged.

## Platform impact

- Samsung Tizen: Unchanged.
- LG webOS: HLS hard buffer cap increased to 80 seconds.
- Browser development mode: Unchanged.
- Installer / packaging: Unchanged.
- Wrapper repositories: Unchanged.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [ ] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only the webOS HLS hard cap changes. The target, back buffer, DASH settings, and other platforms remain unchanged.

## Testing

Verified that the webOS HLS configuration resolves to an 18-second target and 80-second cap, then built the production bundle.

### Devices / platforms tested

LG C5 running webOS 25 for the issue reproduction.

### Commands tested

```sh
npm run build
```

## Manual test flow

Imported `PlayerController` with the webOS platform override and verified `buildHlsConfig()` returns `18/80`.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low and limited to webOS HLS. Lower-bitrate streams may use more of the existing 60 MB byte budget; the 18-second high-bitrate target is unchanged.

## Breaking changes

None.

## Linked issues

Fixes #893
