### PR TITLE
Treat Simkl playback as watched at 80 percent

### DIFF
--- a/js/domain/model/watchProgress.js
+++ b/js/domain/model/watchProgress.js
@@ -18,9 +18,18 @@ export function createWatchProgress({
 
 export const WATCH_PROGRESS_STARTED_THRESHOLD = 0.02;
 export const WATCH_PROGRESS_COMPLETED_THRESHOLD = 0.9;
+// Simkl playback sessions report completion earlier than local progress, so
+// Android treats them as finished at 80% instead of 90%.
+export const WATCH_PROGRESS_SIMKL_COMPLETED_THRESHOLD = 0.8;
 // Android keeps a small in-progress marker when a player cannot expose a
 // meaningful duration (the usual case for live streams).
 export const WATCH_PROGRESS_UNKNOWN_DURATION_PERCENT = 5;
+
+export function watchProgressCompletedThreshold(progress = {}) {
+  return String(progress?.source || "") === "simkl_playback"
+    ? WATCH_PROGRESS_SIMKL_COMPLETED_THRESHOLD
+    : WATCH_PROGRESS_COMPLETED_THRESHOLD;
+}
 
 export function getWatchProgressFraction(progress = {}) {
   const positionMs = Number(progress?.positionMs || 0);
@@ -43,13 +52,14 @@ export function getWatchProgressFraction(progress = {}) {
 }
 
 export function isWatchProgressCompleted(progress = {}) {
-  return getWatchProgressFraction(progress) >= WATCH_PROGRESS_COMPLETED_THRESHOLD;
+  return getWatchProgressFraction(progress) >= watchProgressCompletedThreshold(progress);
 }
 
 export function isWatchProgressInProgress(progress = {}) {
   const fraction = getWatchProgressFraction(progress);
   return (
-    fraction >= WATCH_PROGRESS_STARTED_THRESHOLD && fraction < WATCH_PROGRESS_COMPLETED_THRESHOLD
+    fraction >= WATCH_PROGRESS_STARTED_THRESHOLD &&
+    fraction < watchProgressCompletedThreshold(progress)
   );
 }
 

--- a/js/domain/model/watchProgress.test.mjs
+++ b/js/domain/model/watchProgress.test.mjs
@@ -1,0 +1,16 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isWatchProgressCompleted, isWatchProgressInProgress } from "./watchProgress.js";
+
+test("simkl playback at 80 percent counts as completed", () => {
+  const progress = { source: "simkl_playback", progressPercent: 80 };
+  assert.equal(isWatchProgressCompleted(progress), true);
+  assert.equal(isWatchProgressInProgress(progress), false);
+});
+
+test("local progress at 85 percent is still in progress", () => {
+  const progress = { source: "local", progressPercent: 85 };
+  assert.equal(isWatchProgressCompleted(progress), false);
+  assert.equal(isWatchProgressInProgress(progress), true);
+});


### PR DESCRIPTION
## Summary

Simkl playback entries now count as watched at 80 percent instead of 90, so a finished Simkl episode leaves Continue Watching like it does on Android.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [ ] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [x] Resume / Watch progress
- [x] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Simkl reports playback as finished earlier than local progress does. Android handles that in `WatchProgress.completionThreshold()`, which returns 0.80 for `simkl_playback` entries and 0.90 for everything else. The web domain model used a single 0.90 threshold for every source, so an episode Simkl already treats as finished stayed in Continue Watching on the web app.

## Issue or approval

Fixes #929

## Reproduction steps

1. Connect a Simkl account in Settings.
2. Watch an episode so Simkl records its playback progress at 80 percent.
3. Let the web app sync Simkl progress.
4. Open Home and look at the Continue Watching row.

## Old behavior

The episode stayed in Continue Watching until it reached 90 percent.

## New behavior

The episode counts as watched at 80 percent and drops out of Continue Watching, matching Android.

## Platform impact

Domain model only, so every platform behaves the same. No platform specific code was touched.

- Samsung Tizen: same fix through the shared web app, no Tizen specific change.
- LG webOS: same fix through the shared web app, no webOS specific change.
- Browser development mode: verified here with a unit test and a build.
- Installer / packaging: not affected.
- Wrapper repositories: not affected.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Only `js/domain/model/watchProgress.js` changed. `watchProgressRepository.js` is the Continue Watching filter and already calls these two functions, so it picks up the fix with no edit.

The duplicate threshold copies in `homeScreen.js`, `metaDetailsScreen.js`, and `cloudLibraryPlaybackStore.js` were left alone on purpose to keep this small. No UI polish, no playback change, and no refactor is included.

## Testing

Verified the failure on `main` and the fix on this branch. Added `js/domain/model/watchProgress.test.mjs`, which mirrors the Android assertion in `SimklProjectionsTest`. It fails on `main` and passes here. `npm run build` finishes clean and Prettier reports no problems on both files.

I have no Tizen or webOS hardware, so this was not tested on a TV. The change is in the shared domain model and carries no platform specific code.

### Devices / platforms tested

Chrome on macOS, plus Node for the unit test.

### Commands tested

```sh
npm run build
node --test js/domain/model/watchProgress.test.mjs
npx prettier --check js/domain/model/watchProgress.js js/domain/model/watchProgress.test.mjs
```

## Manual test flow

Seeded a `simkl_playback` progress entry at 80 percent and read it back through the Continue Watching filter. On `main` the entry was still returned as in progress. With this change it is reported as completed and no longer appears. A local entry at 85 percent still shows as in progress, so the ordinary 0.90 threshold is untouched.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable, no playback change.

## Regression risk

Low. Only entries whose source is `simkl_playback` change classification, and only inside the 80 to 89.99 percent band. Every other source keeps the 0.90 threshold. `playerController.js` imports only the unknown duration constant from this module, so it is unaffected.

## Breaking changes

None.

## Linked issues

Fixes #929
