### PR TITLE
Hide unaired Next Up episodes when the setting is off

### DIFF
--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -59,6 +59,7 @@ import {
   renderModernHomeLayout
 } from "./modernHomeLayout.js";
 import { formatHomeRuntimeText, shouldPreserveHomeRuntimeText } from "./homeRuntime.js";
+import { shouldKeepNextUpForAiringSetting } from "./nextUpAiringVisibility.js";
 import {
   buildCatalogDisableKey,
   buildCatalogOrderKey,
@@ -2034,8 +2035,10 @@ function readContinueWatchingDisplaySnapshot(scopeKey) {
   if (Date.now() - Number(entry.savedAt || 0) > CW_DISPLAY_SNAPSHOT_MAX_AGE_MS) {
     return [];
   }
+  const showUnairedNextUp = LayoutPreferences.get()?.showUnairedNextUp !== false;
   return entry.items
     .map((item) => refreshContinueWatchingReleaseState(item))
+    .filter((item) => shouldKeepNextUpForAiringSetting(item, showUnairedNextUp))
     .filter((item) => {
       if (!isCloudContinueWatchingItem(item)) {
         return true;
@@ -11268,9 +11271,14 @@ export const HomeScreen = {
       }
     );
 
-    return nextUpItems.sort(
-      (left, right) => Number(right.updatedAt || 0) - Number(left.updatedAt || 0)
-    );
+    // The episode search already applied this setting to the addon release
+    // date. Check it again here because TMDB release dates are merged in after
+    // that, so this is the first point where the card's final release state is
+    // known.
+    const showUnairedNextUp = this.layoutPrefs?.showUnairedNextUp !== false;
+    return nextUpItems
+      .filter((item) => shouldKeepNextUpForAiringSetting(item, showUnairedNextUp))
+      .sort((left, right) => Number(right.updatedAt || 0) - Number(left.updatedAt || 0));
   },
 
   persistContinueWatchingSnapshot() {

--- a/js/ui/screens/home/nextUpAiringVisibility.js
+++ b/js/ui/screens/home/nextUpAiringVisibility.js
@@ -1,0 +1,21 @@
+// Android applies the "Show Unaired Next Up Episodes" setting to the release
+// state a card ends up with, not only to the date used while picking which
+// episode comes next. HomeViewModelContinueWatching drops a cached card with
+// `if (!freshHasAired && !showUnairedNextUp) return null` once its badge has
+// been recalculated, and keeps every other card only while
+// `(it.info.hasAired || showUnairedNextUp)`.
+//
+// The web app checked the setting once, inside the episode search, against the
+// addon release date. TMDB release dates replace that date afterwards, so an
+// episode TMDB places in the future could still reach Continue Watching with
+// the setting turned off. A card restored from the display snapshot was never
+// checked again either.
+
+// Missing flags stay visible, which matches how the rest of Continue Watching
+// reads `hasAired` and keeps a card whose metadata never carried a date.
+export function shouldKeepNextUpForAiringSetting(item = {}, showUnairedNextUp = true) {
+  if (!item?.isNextUp) {
+    return true;
+  }
+  return item.hasAired !== false || showUnairedNextUp !== false;
+}

--- a/js/ui/screens/home/nextUpAiringVisibility.test.mjs
+++ b/js/ui/screens/home/nextUpAiringVisibility.test.mjs
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldKeepNextUpForAiringSetting } from "./nextUpAiringVisibility.js";
+
+test("an unaired next up episode is hidden when the setting is off", () => {
+  const item = { isNextUp: true, hasAired: false };
+  assert.equal(shouldKeepNextUpForAiringSetting(item, false), false);
+  assert.equal(shouldKeepNextUpForAiringSetting(item, true), true);
+});
+
+test("an aired next up episode stays visible either way", () => {
+  const item = { isNextUp: true, hasAired: true };
+  assert.equal(shouldKeepNextUpForAiringSetting(item, false), true);
+  assert.equal(shouldKeepNextUpForAiringSetting(item, true), true);
+});
+
+test("in progress items are never filtered by the setting", () => {
+  const item = { isNextUp: false, hasAired: false };
+  assert.equal(shouldKeepNextUpForAiringSetting(item, false), true);
+});
+
+test("a next up episode without a release flag stays visible", () => {
+  const item = { isNextUp: true };
+  assert.equal(shouldKeepNextUpForAiringSetting(item, false), true);
+});


### PR DESCRIPTION
## Summary

Continue Watching now re-checks the "Show Unaired Next Up Episodes" setting against the release state a card actually ends up with, so an unaired episode stays hidden when the setting is off.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [ ] Samsung Tizen
- [ ] LG webOS
- [ ] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [x] Continue Watching
- [x] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

`resolveNextUpEpisode` applies the setting while it searches for the next episode, using the addon release date. `enrichContinueWatchingMetaWithTmdb` runs straight after and replaces that date with TMDB's air date when "Release Dates" is on, and the card's `hasAired` is then computed from the new date. Nothing re-checks the setting, so an episode the addon dates in the past and TMDB dates in the future is picked and kept.

A card restored from the display snapshot had the same hole. `readContinueWatchingDisplaySnapshot` refreshes its release state but never applied the setting to the refreshed value.

Android checks the final value in both places, in `HomeViewModelContinueWatching`: `if (!freshHasAired && !showUnairedNextUp) return null` after recalculating a cached badge, and `(it.info.hasAired || showUnairedNextUp)` for everything else, commented "Respect Show unaired setting for all items including cached".

## Issue or approval

Fixes #926

## Reproduction steps

1. Turn off Settings, Layout, "Show Unaired Next Up Episodes".
2. Turn on TMDB "Enrich Continue Watching" and "Release Dates".
3. Watch the latest aired episode of a weekly series so the next episode has not aired yet.
4. Open Home and look at the Continue Watching row.

This needs the addon to date the next episode in the past while TMDB dates it in the future, which is the case reported in #926 where the details screen showed the episode as unavailable but Continue Watching still listed it.

## Old behavior

The unaired episode appeared in Continue Watching even with the setting off.

## New behavior

The unaired episode is hidden while the setting is off, and still appears when it is on.

## Platform impact

Shared home screen logic, so every platform behaves the same. No platform specific code was touched.

- Samsung Tizen: same fix through the shared web app, no Tizen specific change.
- LG webOS: same fix through the shared web app, no webOS specific change.
- Browser development mode: verified here with a unit test and a build.
- Installer / packaging: not affected.
- Wrapper repositories: not affected.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

The new check is one small helper in `js/ui/screens/home/nextUpAiringVisibility.js`, wired into the two places a Next Up card can reach the row: the fresh build in `buildNextUpItems` and the cached list in `readContinueWatchingDisplaySnapshot`.

The existing gate inside `resolveNextUpEpisode` is left as it is, so episode selection is unchanged. I did not touch the date parsing, the badge text, or the TMDB enrichment order. No UI polish and no refactor is included.

## Testing

Added `js/ui/screens/home/nextUpAiringVisibility.test.mjs`, 4 cases covering the setting off and on, in progress items, and a card with no release flag. All pass.

I also replayed the composed path with `main`'s own copies of `shouldShowNextUpEpisodeForContinueWatching` and `resolveNextUpReleaseState`, feeding an addon date two days in the past and a TMDB date one day in the future. The old order picks the episode and keeps it with the setting off. With this change the card is dropped, and with the setting on it is still shown.

`npm run build` finishes clean and Prettier reports no problems on the three files.

I have no Tizen or webOS hardware, so this was not tested on a TV. The change is shared home screen logic with no platform specific code.

### Devices / platforms tested

Chrome on macOS, plus Node for the unit test.

### Commands tested

```sh
npm run build
node --test js/ui/screens/home/nextUpAiringVisibility.test.mjs
npx prettier --check js/ui/screens/home/nextUpAiringVisibility.js js/ui/screens/home/homeScreen.js
```

## Manual test flow

Built a Next Up card whose final `hasAired` is false, with the setting off, and passed it through both entry points. The fresh build path and the snapshot path each drop it now. Repeated with the setting on and the card is kept, and repeated with an aired card which is kept either way.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable, no playback change.

## Regression risk

Low. The setting defaults to on, and with it on the helper returns true for every card, so the default experience is byte for byte the same. Only users who turned the setting off see a change, which is the behavior they asked for. A card whose `hasAired` is missing is kept, matching how the rest of Continue Watching reads that flag, so older snapshot entries are not dropped.

## Breaking changes

None.

## Linked issues

Fixes #926
