### PR TITLE
perf(home): batch text measurements and reduce spring-scroll layout reads

### DIFF
--- a/js/ui/screens/home/homeScreen.js
+++ b/js/ui/screens/home/homeScreen.js
@@ -3755,10 +3755,11 @@ export const HomeScreen = {
       state.position += state.velocity * deltaSeconds;
       container[property] = state.position;
 
-      const remaining = Number(state.target || 0) - Number(container[property] || 0);
+      // Reading scroll position after writing it can flush layout. It only
+      // affects settling once velocity is low enough; keep that check first.
       if (
-        Math.abs(remaining) <= state.precision &&
-        Math.abs(state.velocity) <= state.velocityEpsilon
+        Math.abs(state.velocity) <= state.velocityEpsilon &&
+        Math.abs(Number(state.target || 0) - Number(container[property] || 0)) <= state.precision
       ) {
         container[property] = state.target;
         existing[key] = null;
@@ -7395,6 +7396,7 @@ export const HomeScreen = {
         ? ".home-hero-description"
         : ".home-hero-description, .home-poster-title, .home-poster-subtitle";
     const nodes = root.querySelectorAll(truncationSelector);
+    const measurements = [];
     nodes.forEach((node) => {
       if (!(node instanceof HTMLElement)) {
         return;
@@ -7414,32 +7416,47 @@ export const HomeScreen = {
       if (!fullText) {
         return;
       }
-      node.dataset.fullText = fullText;
-      node.textContent = wordTrimmed ? `${fullText}...` : fullText;
-      const fits =
-        node.scrollWidth <= node.clientWidth + 1 && node.scrollHeight <= node.clientHeight + 1;
-      if (fits) {
-        node.classList.toggle("is-truncated", wordTrimmed);
-        return;
+      if (node.dataset.fullText !== fullText) {
+        node.dataset.fullText = fullText;
       }
+      const initialText = wordTrimmed ? `${fullText}...` : fullText;
+      if (node.textContent !== initialText) {
+        node.textContent = initialText;
+      }
+      measurements.push({ node, fullText, wordTrimmed, low: 0, high: fullText.length });
+    });
 
-      const ellipsis = "...";
-      let low = 0;
-      let high = fullText.length;
-      while (low < high) {
-        const mid = Math.ceil((low + high) / 2);
-        node.textContent = `${fullText.slice(0, mid).trimEnd()}${ellipsis}`;
-        const overflows =
-          node.scrollWidth > node.clientWidth + 1 || node.scrollHeight > node.clientHeight + 1;
-        if (overflows) {
-          high = mid - 1;
+    // All labels share each layout flush instead of forcing one per label and
+    // binary-search step. Keep the same overflow tolerance and search bounds.
+    let pending = measurements.filter(
+      ({ node }) =>
+        node.scrollWidth > node.clientWidth + 1 || node.scrollHeight > node.clientHeight + 1
+    );
+    const overflowing = new Set(pending);
+    while (pending.length) {
+      pending.forEach((entry) => {
+        entry.mid = Math.ceil((entry.low + entry.high) / 2);
+        entry.node.textContent = `${entry.fullText.slice(0, entry.mid).trimEnd()}...`;
+      });
+      pending.forEach((entry) => {
+        const { node } = entry;
+        if (node.scrollWidth > node.clientWidth + 1 || node.scrollHeight > node.clientHeight + 1) {
+          entry.high = entry.mid - 1;
         } else {
-          low = mid;
+          entry.low = entry.mid;
+        }
+      });
+      pending = pending.filter((entry) => entry.low < entry.high);
+    }
+    measurements.forEach((entry) => {
+      const { node, fullText, low, wordTrimmed } = entry;
+      if (overflowing.has(entry)) {
+        const finalText = `${fullText.slice(0, Math.max(0, low)).trimEnd()}...`;
+        if (node.textContent !== finalText) {
+          node.textContent = finalText;
         }
       }
-      const finalText = `${fullText.slice(0, Math.max(0, low)).trimEnd()}${ellipsis}`;
-      node.textContent = finalText;
-      node.classList.add("is-truncated");
+      node.classList.toggle("is-truncated", overflowing.has(entry) || wordTrimmed);
     });
   },
 
@@ -7452,17 +7469,17 @@ export const HomeScreen = {
     const heroNodes = scope.classList?.contains("home-hero-card")
       ? [scope]
       : Array.from(scope.querySelectorAll(".home-hero-card"));
-    heroNodes.forEach((heroNode) => {
-      const description = heroNode.querySelector(".home-hero-description");
-      if (!(description instanceof HTMLElement)) {
-        return;
-      }
-
+    const descriptions = heroNodes
+      .map((heroNode) => heroNode.querySelector(".home-hero-description"))
+      .filter((description) => description instanceof HTMLElement);
+    descriptions.forEach((description) => {
       description.style.maxHeight = "";
       description.style.webkitLineClamp = "";
       description.style.lineClamp = "";
+    });
+    const bounds = descriptions.map((description) => {
       if (description.classList.contains("is-empty")) {
-        return;
+        return null;
       }
 
       const descriptionStyle = getComputedStyle(description);
@@ -7472,7 +7489,12 @@ export const HomeScreen = {
         1,
         Math.ceil(lineHeight || fontSize * 1.35 || description.offsetHeight || 1)
       );
-      description.style.maxHeight = `${lineBoxHeight * modernHeroDescriptionMaxLines}px`;
+      return { description, maxHeight: `${lineBoxHeight * modernHeroDescriptionMaxLines}px` };
+    });
+    bounds.forEach((entry) => {
+      if (entry) {
+        entry.description.style.maxHeight = entry.maxHeight;
+      }
     });
   },
 


### PR DESCRIPTION
## Summary

Reduce unnecessary layout work in Home text fitting and spring scrolling.

- Batch text writes and overflow measurements across labels.
- Batch modern hero description height calculations.
- Read the DOM scroll position only when spring velocity permits settling.

Only `js/ui/screens/home/homeScreen.js` changes. Existing text output, scroll integration, animation timing, and navigation rules are preserved.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix
- [ ] Approved feature/change

Pending classification: this is focused performance maintenance. No linked critical bug or explicit maintainer approval is currently available.

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [x] Focus / Remote navigation
- [x] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

Home text truncation alternated DOM writes and layout measurements for every label and every binary-search step, repeatedly forcing layout. Spring scrolling also read the DOM scroll position immediately after every frame's write, even when velocity was too high for the animation to settle. Both paths perform avoidable work on the rendering thread.

## Issue or approval

No linked issue or explicit maintainer approval yet. This change is proposed as small maintenance work without UI or behavior changes. The applicable template category needs confirmation before submission.

## Reproduction steps

To measure the existing overhead:

1. Build with `npm run package:webos`.
2. Launch `.cache/webos-package/app` in webOS TV 26 Simulator 1.5.0.
3. Keep the simulator restored and foregrounded.
4. Record CPU and timeline profiles while moving horizontally through catalog cards, entering and traversing the sidebar, returning to content, and moving vertically.
5. Inspect spring-scroll callbacks and forced layout measurements.
6. Exercise text truncation with long labels in classic/grid layouts and hero descriptions in modern layout, including repeated passes and narrower widths.

## Old behavior

Text fitting wrote and measured each label independently during its binary search. Modern hero height calculations also interleaved resets, reads, and writes.

Spring scrolling read the DOM scroll position on every animation frame before checking whether velocity was low enough to settle.

## New behavior

Text fitting batches writes and reads by binary-search iteration so labels share layout flushes. Modern hero height calculations similarly separate resets, measurements, and updates.

Spring scrolling checks velocity first and reads the DOM scroll position only when it could affect completion.

The existing word limit, ellipsis, overflow tolerance, search bounds, truncation classes, spring integration, scroll writes, and stopping criteria remain unchanged.

## Platform impact

- Samsung Tizen: Uses the modified shared Home code. No Tizen-specific APIs change. Not tested on Tizen hardware or an emulator.
- LG webOS: Profiled and compared in webOS TV 26 Simulator 1.5.0, using Chromium 132. No webOS-specific APIs change.
- Browser development mode: Uses the same shared code. No separate browser-mode regression run was performed.
- Installer / packaging: No changes. Production webOS packaging succeeds.
- Wrapper repositories: No changes.

## UI / behavior / playback impact

- [x] No UI change
- [x] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [ ] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, broad UI changes, refactors, playback rewrites, platform rewrites, installer rewrites, and other non-critical changes may be closed or deferred without review while Nuvio TV is being prepared for a stable Smart TV release.

The unchecked items remain pending classification and an issue/approval link. This change is not being presented as a documented critical bug fix.

## Scope boundaries

Limited to Home text measurement and spring-scroll layout reads.

No CSS, markup templates, navigation mappings, animation constants, delays, playback code, settings, dependencies, package metadata, or wrapper behavior changes.

## Testing

Measured with the simulator's Chromium DevTools Protocol CPU profiler, Performance metrics, timeline tracing, and screenshots.

Matched 31-key navigation sequence:

| Metric | Baseline | Optimized |
| --- | ---: | ---: |
| Layout count | 152 | 108 |
| Layout time | 28.79 ms | 17.94 ms |
| Style recalculations | 741 | 714 |
| Script time | 118.78 ms | 108.63 ms |
| Total task time | 1500.07 ms | 1436.38 ms |

Every focus destination matched between these two runs. These are individual simulator measurements, not physical-TV benchmarks or statistical guarantees.

A 180-label stress fixture compared initial truncation, repeated truncation, and narrowed widths:

| Three-pass layout count | Baseline | Optimized |
| --- | ---: | ---: |
| Classic | 2703 | 27 |
| Grid | 2703 | 27 |
| Modern | 4899 | 43 |

Output text, stored full text, truncation classes, and height limits matched. Cases included Japanese, accented text, empty text, existing ellipses, and descriptions exceeding 40 words. The modern fixture intentionally contains more hero descriptions than a normal Home screen.

Additional checks:

- Pixel-identical controlled screenshots across modern portrait, classic, grid, modern landscape, and modern sidebar.
- All 12 deterministic spring checks matched every scroll write and completion frame across both axes, 30/60/120 Hz, and mid-animation retargeting.
- Spring DOM position reads fell from 37–115 to two per case.
- Four existing Home tests passed.
- Final production package loaded Home in the simulator without test instrumentation.

### Devices / platforms tested

- Windows host.
- LG webOS TV 26 Simulator 1.5.0, Chromium 132.
- No physical TV testing.

### Commands tested

Passed:

```sh
npm run build
npm run lint
npx --no-install prettier --check js/ui/screens/home/homeScreen.js
npm run format:check
node --test js/ui/screens/home/*.test.mjs
git diff --check
npm run package:webos
```

`npm test` completed the build but could not run the plugin suite because this checkout lacks `tests/test-plugin-system.mjs`.

The package build used `local.example.properties` because `local.properties` was absent. The staged app was run in the simulator; physical-TV IPK installation was not tested.

## Manual test flow

Simulator inspection and automated input were used:

1. Load Home and inspect the hero, catalog cards, and sidebar.
2. Traverse a catalog row in both directions.
3. Enter and traverse the sidebar, return to content, and move vertically.
4. Compare focus destinations between baseline and optimized methods.
5. Compare settled text and geometry across the five layout configurations.
6. Compare screenshots on the same settled DOM, with CSS animations paused only for pixel comparison.

A separate automated route smoke test passed horizontal round trips and opening details. Its sidebar-selection, detail Back-focus, and long-press assertions failed with both baseline and optimized methods in this session. Those flows remain unverified; no uncaught JavaScript exceptions were recorded.

## Screenshots / Video

Not a UI change.

Controlled baseline/optimized screenshot comparisons were pixel-identical across the five tested layout configurations. Captures are retained locally in `.cache/menu-performance/`; no screenshots or video are attached.

## Logs

Not applicable to a crash, playback, installation, or platform API fix.

Local CPU profiles, timeline traces, and comparison outputs are retained in `.cache/menu-performance/`. The separate route smoke runs recorded no uncaught JavaScript exceptions.

## Regression risk

The modified code is shared across webOS, Tizen, and browser development mode.

Potential risks include differences in text wrapping or layout measurement on older Chromium versions, and differences in scroll-position rounding across runtimes. Simulator comparisons preserved text output and spring trajectories, but physical TVs, Tizen, and standalone browser mode were not tested.

Full route regression verification remains incomplete because the separate route smoke assertions also failed against baseline methods. The repository-wide plugin suite could not run because its test files are missing.

## Breaking changes

None.

## Linked issues

No linked issue yet. A relevant issue or maintainer-approved request is still needed.
