### PR TITLE
fix(sync): preserve regional TMDB language codes in TV profile settings

### DIFF
--- a/js/core/profile/profileSettingsSyncService.js
+++ b/js/core/profile/profileSettingsSyncService.js
@@ -568,11 +568,15 @@ function normalizeContinueWatchingSortModeForWeb(value) {
 }
 
 function normalizeTmdbLanguageForAndroid(value) {
-  const normalized = String(value || "en").trim();
+  const normalized = String(value || "")
+    .trim()
+    .replace(/_/g, "-");
   if (!normalized) {
     return "en";
   }
-  return normalized.split(/[-_]/)[0].toLowerCase() || "en";
+
+  // Android's TMDB catalogue stores Portuguese (Brazil) as lowercase "pt-br".
+  return normalized === "pt-BR" ? "pt-br" : normalized;
 }
 
 function normalizeTmdbLanguageForWeb(value) {


### PR DESCRIPTION
## Summary

Preserve regional TMDB language codes when syncing TV profile settings.

Previously, the sync layer stripped the region from values such as `es-419`, `en-GB`, or `zh-CN`, which could cause the selected language to revert after syncing between TV clients.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix
- [ ] Approved feature/change

## Affected area

- [x] Shared web app
- [x] Samsung Tizen
- [x] LG webOS
- [x] Browser development mode
- [ ] Playback
- [ ] Audio tracks
- [ ] Subtitles
- [ ] Focus / Remote navigation
- [ ] UI / Layout
- [ ] Resume / Watch progress
- [ ] Continue Watching
- [ ] Next Episode / Auto-play
- [ ] Packaging / Build
- [ ] Nuvio TV Installer compatibility
- [ ] webOS Homebrew wrapper
- [ ] Documentation
- [ ] Other

## Why

TV profile settings are shared between the Smart TV app and Android TV.

`normalizeTmdbLanguageForAndroid()` previously reduced regional language codes to their base language, for example:

- `es-419` → `es`
- `en-GB` → `en`
- `zh-CN` → `zh`
- `pt-BR` → `pt`

This meant a regional language selected by the user could be overwritten with the base language during sync.

The fix keeps the regional code intact. `pt-BR` is exported as `pt-br` because that is the value used by the Android TV language catalogue.

## Issue or approval

Discord bug report:

https://discord.com/channels/1379902184207941732/1548374979815542784

## Reproduction steps

1. Sign in to the same profile on Smart TV and Android TV.
2. Set TMDB language to **Spanish (Latin America)**.
3. Trigger a settings sync from the Smart TV app.
4. Pull/reload the profile settings on Android TV.
5. The selected language may revert from `es-419` to `es`.

## Old behavior

Regional TMDB language codes were collapsed to their base language before being written to the shared TV settings.

For example, `es-419` became `es`.

## New behavior

Regional TMDB language codes are preserved during sync.

Examples:

- `es-419` stays `es-419`
- `en-GB` stays `en-GB`
- `zh-CN` stays `zh-CN`
- `pt-BR` is exported as `pt-br` for Android TV compatibility

## Platform impact

- Samsung Tizen: affected through the shared web app sync code.
- LG webOS: affected through the shared web app sync code.
- Browser development mode: uses the same shared code.
- Installer / packaging: no impact.
- Wrapper repositories: no impact.

## UI / behavior / playback impact

- [x] No UI change
- [ ] No behavior change
- [x] No playback change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] Playback changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval
- [ ] Playback change has explicit maintainer approval

## Installer, packaging, or wrapper impact

- [x] No installer, packaging, or wrapper impact
- [ ] Tizen `.wgt` packaging changed
- [ ] webOS `.ipk` packaging changed
- [ ] App identifiers or metadata changed
- [ ] `local.properties` / environment handling changed
- [ ] `sync:tizen` changed
- [ ] `sync:webos` changed
- [ ] Nuvio TV Installer compatibility changed
- [ ] webOS Homebrew metadata support changed

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy or has explicit maintainer approval.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, platform rewrites, installer rewrites, or broad refactors without approval.
- [x] This PR does not change UI unless it fixes a linked glitch/bug or has explicit approval.
- [x] This PR does not change behavior unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change playback unless it fixes a linked bug/regression or has explicit approval.
- [x] This PR does not change installer, packaging, app identifiers, release flow, or wrapper behavior without clear need or approval.
- [x] I included a linked issue, reproduction steps, and testing notes if this is a critical bug fix.
- [x] I listed the testing performed below.

> Feature additions, broad UI changes, refactors, playback rewrites, platform rewrites, installer rewrites, and other non-critical changes may be closed or deferred without review while Nuvio TV is being prepared for a stable Smart TV release.

## Scope boundaries

Only `normalizeTmdbLanguageForAndroid()` in `js/core/profile/profileSettingsSyncService.js` was changed.

No UI, playback, TMDB request logic, translations, packaging, wrappers, or unrelated code were changed.

## Testing

Static checks were run successfully.

The sync path and Android TV language catalogue were also reviewed to confirm that regional values such as `es-419`, `zh-CN`, and `pt-br` are supported.

### Devices / platforms tested

Static verification only; no physical Smart TV or Android TV device was used for this change.

### Commands tested

```sh
node --check js/core/profile/profileSettingsSyncService.js
npx prettier --check js/core/profile/profileSettingsSyncService.js
```

## Manual test flow

1. Select **Spanish (Latin America)** in TMDB settings.
2. Trigger a profile settings sync.
3. Reload the same profile on Android TV.
4. Confirm the language remains **Spanish (Latin America)**.
5. Repeat after restarting/resyncing both clients.
6. Repeat with **Portuguese (Brazil)** and confirm it remains selected correctly.

## Screenshots / Video

Not a UI change.

## Logs

Not applicable.

## Regression risk

Low.

The change only affects how the TMDB language value is written to the shared TV settings. Regional codes are preserved instead of being reduced to the base language.

## Breaking changes

None.

## Linked issues

Discord bug report:

https://discord.com/channels/1379902184207941732/1548374979815542784
